### PR TITLE
feat: remove temp path from bridge's start call

### DIFF
--- a/android/app/src/main/java/foundation/privacybydesign/irmamobile/irma_mobile_bridge/IrmaMobileBridge.java
+++ b/android/app/src/main/java/foundation/privacybydesign/irmamobile/irma_mobile_bridge/IrmaMobileBridge.java
@@ -31,7 +31,7 @@ public class IrmaMobileBridge implements MethodCallHandler, irmagobridge.IrmaMob
 
     try {
       PackageInfo pi = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
-      Irmagobridge.start(this, pi.applicationInfo.dataDir, copier.destAssetsPath.toString(), context.getFilesDir().getPath() + "/tmp");
+      Irmagobridge.start(this, pi.applicationInfo.dataDir, copier.destAssetsPath.toString());
       this.debug = (pi.applicationInfo.flags & ApplicationInfo.FLAG_DEBUGGABLE) != 0;
     } catch (PackageManager.NameNotFoundException e) {
       throw new RuntimeException(e);

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jasonlvhit/gocron v0.0.0-20191111122648-5c21418a78e8 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/privacybydesign/gabi v0.0.0-20200823153621-467696543652
-	github.com/privacybydesign/irmago v0.6.1-0.20201125175402-f7d6101f8dbd
+	github.com/privacybydesign/irmago v0.6.1-0.20210111123110-52524f5b9f7b
 	github.com/sirupsen/logrus v1.4.2
 	github.com/timshannon/bolthold v0.0.0-20191212204344-59576e1e7b0b // indirect
 	go.etcd.io/bbolt v1.3.3 // indirect

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jasonlvhit/gocron v0.0.0-20191111122648-5c21418a78e8 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/privacybydesign/gabi v0.0.0-20200823153621-467696543652
-	github.com/privacybydesign/irmago v0.6.1-0.20210111123110-52524f5b9f7b
+	github.com/privacybydesign/irmago v0.6.2-0.20210112152806-f0682024c56a
 	github.com/sirupsen/logrus v1.4.2
 	github.com/timshannon/bolthold v0.0.0-20191212204344-59576e1e7b0b // indirect
 	go.etcd.io/bbolt v1.3.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -286,8 +286,14 @@ github.com/privacybydesign/irmago v0.5.1-0.20201016100546-c79b1aab3c55 h1:pPryIl
 github.com/privacybydesign/irmago v0.5.1-0.20201016100546-c79b1aab3c55/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
 github.com/privacybydesign/irmago v0.6.0 h1:DbaJWtSEVsULKnZaADusSTLdjODSBouQzWC2Lj9Y9lU=
 github.com/privacybydesign/irmago v0.6.0/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
+github.com/privacybydesign/irmago v0.6.1-0.20201119111152-0e98cba98bca h1:JFc4WlDd02/1zmZpD2EIpdtlpnwwU7ibpvDF0D7lDM4=
+github.com/privacybydesign/irmago v0.6.1-0.20201119111152-0e98cba98bca/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
 github.com/privacybydesign/irmago v0.6.1-0.20201125175402-f7d6101f8dbd h1:cMk6RGZ2jhe23m6QsBPyCKXFh5uOQyVtVctFKBZ3+NU=
 github.com/privacybydesign/irmago v0.6.1-0.20201125175402-f7d6101f8dbd/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
+github.com/privacybydesign/irmago v0.6.1-0.20210111122809-86b363df3bb0 h1:J+6Z1gE3qW03qU6PdAj31gnADEwyf8wjknDw1M90jjM=
+github.com/privacybydesign/irmago v0.6.1-0.20210111122809-86b363df3bb0/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
+github.com/privacybydesign/irmago v0.6.1-0.20210111123110-52524f5b9f7b h1:jKuGJrKYwo5cKAJtUF1HV1Ce9PqMw6EfmVV7trsxB4Y=
+github.com/privacybydesign/irmago v0.6.1-0.20210111123110-52524f5b9f7b/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=

--- a/go.sum
+++ b/go.sum
@@ -112,6 +112,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -159,6 +160,7 @@ github.com/jinzhu/now v1.0.1/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
@@ -294,6 +296,10 @@ github.com/privacybydesign/irmago v0.6.1-0.20210111122809-86b363df3bb0 h1:J+6Z1g
 github.com/privacybydesign/irmago v0.6.1-0.20210111122809-86b363df3bb0/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
 github.com/privacybydesign/irmago v0.6.1-0.20210111123110-52524f5b9f7b h1:jKuGJrKYwo5cKAJtUF1HV1Ce9PqMw6EfmVV7trsxB4Y=
 github.com/privacybydesign/irmago v0.6.1-0.20210111123110-52524f5b9f7b/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
+github.com/privacybydesign/irmago v0.6.1-0.20210112150146-768c9a6f61fe h1:DhjQKHl+kKUgyFpW7EaMa85x+jrXsijnS609ujZXqIg=
+github.com/privacybydesign/irmago v0.6.1-0.20210112150146-768c9a6f61fe/go.mod h1:S5eKWg1bk0y8x3UBzDPqUNx3wweU/V6RG1JzK742kAc=
+github.com/privacybydesign/irmago v0.6.2-0.20210112152806-f0682024c56a h1:QW9agUCQ+WbSS0ZFcXBvoq43DOXAREz0PvUwDmCBMWc=
+github.com/privacybydesign/irmago v0.6.2-0.20210112152806-f0682024c56a/go.mod h1:Vml9NoGIDVnFVbXd6tvyiHlB/dbqN2yfYYctKLlkQQE=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
@@ -321,6 +327,8 @@ github.com/sietseringers/viper v1.3.2-0.20200909194413-4120aa4ee8e8/go.mod h1:bC
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
+github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
+github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
@@ -459,6 +467,7 @@ golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312151545-0bb0c0a6e846/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190312170243-e65039ee4138/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190425150028-36563e24a262/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190506145303-2d16b83fe98c/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
 golang.org/x/tools v0.0.0-20190524210228-3d17549cdc6b/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=

--- a/ios/Runner/IrmaMobileBridgePlugin.m
+++ b/ios/Runner/IrmaMobileBridgePlugin.m
@@ -37,7 +37,7 @@
   }
 
   [self debugLog:[NSString stringWithFormat:@"Starting irmago, lib=%@, bundle=%@", libraryPath, bundlePath]];
-  IrmagobridgeStart(self, libraryPath, bundlePath, @"");
+  IrmagobridgeStart(self, libraryPath, bundlePath);
   return self;
 }
 

--- a/irmagobridge/bridge.go
+++ b/irmagobridge/bridge.go
@@ -47,7 +47,7 @@ func (p writer) Write(b []byte) (int, error) {
 }
 
 // Start is invoked from the native side, when the app starts
-func Start(givenBridge IrmaMobileBridge, appDataPath string, assetsPath string, tempPath string) {
+func Start(givenBridge IrmaMobileBridge, appDataPath string, assetsPath string) {
 	defer recoverFromPanic()
 
 	bridge = givenBridge
@@ -79,7 +79,7 @@ func Start(givenBridge IrmaMobileBridge, appDataPath string, assetsPath string, 
 
 	// Initialize the client
 	configurationPath := filepath.Join(assetsPath, "irma_configuration")
-	client, err = irmaclient.New(appVersionDataPath, configurationPath, bridgeClientHandler, tempPath)
+	client, err = irmaclient.New(appVersionDataPath, configurationPath, bridgeClientHandler)
 	if err != nil {
 		reportError(errors.WrapPrefix(err, "Cannot initialize client", 0))
 		return


### PR DESCRIPTION
Uses [this branch](https://github.com/privacybydesign/irmago/pull/108) of `irmago`, which does not include a temp path in it's client's configuration. This should only impact Android, but I will test this on both platforms.

Note: before merging this MR, we should update `go.mod` to point towards the latest `irmago` commit after merging https://github.com/privacybydesign/irmago/pull/108.