### PR TITLE
Adjust English Error Title

### DIFF
--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -330,7 +330,7 @@
     "explanation": "For your safety, the IRMA app regularly asks for your PIN."
   },
   "error": {
-    "title": "Something goes wrong",
+    "title": "Something went wrong",
     "blocked_title": "App blocked",
     "button_ok": "OK",
     "button_send_to_irma": "Send to IRMA's technical team",


### PR DESCRIPTION
Although very minor, I wish to propose an adjustment of the English error title. Saying something goes wrong is technically correct, but it sounds very odd and is not consistent with wording used in the rest of the IRMA app. Hence, I wish to propose making it consistent.