### PR TITLE
Chore: move build numbering logic to build.gradle and include univers…

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -142,9 +142,9 @@ jobs:
         with:
           name: app-alpha-android-alpha
       - name: Download app-alpha-android-beta artifact
-          uses: actions/download-artifact@v3
-          with:
-            name: app-alpha-android-beta
+        uses: actions/download-artifact@v3
+        with:
+          name: app-alpha-android-beta
       - name: Bundle all artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -99,9 +99,6 @@ jobs:
       - unit-test
       - build-irmagobridge-android
     environment: ad-hoc-alpha
-    strategy:
-      matrix:
-        target-platform: [ android-arm, android-arm64, android-x64 ]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -118,11 +115,10 @@ jobs:
         run: >
           bundle exec fastlane android_build_app
           flavor:alpha
-          target_platform:${{ matrix.target-platform }}
           sentry_dsn:${{ secrets.SENTRY_DSN }}
       - uses: actions/upload-artifact@v3
         with:
-          name: app-alpha-${{ matrix.target-platform }}
+          name: app-alpha-android
           path: ./fastlane/build/*.apk
   bundle-app-alpha:
     runs-on: ubuntu-latest
@@ -134,18 +130,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: app-alpha-ios
-      - name: Download app-alpha-android-arm artifact
+      - name: Download app-alpha-android artifact
         uses: actions/download-artifact@v3
         with:
-          name: app-alpha-android-arm
-      - name: Download app-alpha-android-arm64 artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: app-alpha-android-arm64
-      - name: Download app-alpha-android-x64 artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: app-alpha-android-x64
+          name: app-alpha-android
       - name: Bundle all artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -226,11 +214,10 @@ jobs:
         run: >
           bundle exec fastlane android_build_app
           flavor:beta
-          target_platform:${{ matrix.target-platform }}
           sentry_dsn:${{ secrets.SENTRY_DSN }}
       - uses: actions/upload-artifact@v3
         with:
-          name: app-beta-${{ matrix.target-platform }}
+          name: app-beta-android
           path: ./fastlane/build/*.apk
   bundle-app-beta:
     runs-on: ubuntu-latest
@@ -242,18 +229,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: app-beta-ios
-      - name: Download app-beta-android-arm artifact
+      - name: Download app-beta-android artifact
         uses: actions/download-artifact@v3
         with:
-          name: app-beta-android-arm
-      - name: Download app-beta-android-arm64 artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: app-beta-android-arm64
-      - name: Download app-beta-android-x64 artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: app-beta-android-x64
+          name: app-beta-android
       - name: Bundle all artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -99,6 +99,12 @@ jobs:
       - unit-test
       - build-irmagobridge-android
     environment: ad-hoc-alpha
+    # For now, we also build the beta flavor using the alpha secrets to enable ad-hoc distribution of the
+    # beta flavor Android app. This is needed, because the irma-frontend-packages use the app identifier of the
+    # beta flavor Android app in the intent:// links.
+    strategy:
+      matrix:
+        flavor: [ alpha, beta ]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -114,11 +120,11 @@ jobs:
       - name: Build app
         run: >
           bundle exec fastlane android_build_app
-          flavor:alpha
+          flavor:${{ matrix.flavor }}
           sentry_dsn:${{ secrets.SENTRY_DSN }}
       - uses: actions/upload-artifact@v3
         with:
-          name: app-alpha-android
+          name: app-alpha-android-${{ matrix.flavor }}
           path: ./fastlane/build/*.apk
   bundle-app-alpha:
     runs-on: ubuntu-latest
@@ -130,10 +136,15 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: app-alpha-ios
-      - name: Download app-alpha-android artifact
+      # Check the comment above in the build-app-android-alpha job spec why the beta is also present here.
+      - name: Download app-alpha-android-alpha artifact
         uses: actions/download-artifact@v3
         with:
-          name: app-alpha-android
+          name: app-alpha-android-alpha
+      - name: Download app-alpha-android-beta artifact
+          uses: actions/download-artifact@v3
+          with:
+            name: app-alpha-android-beta
       - name: Bundle all artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -81,7 +81,6 @@ jobs:
     strategy:
       matrix:
         flavor: [ alpha, beta ]
-        target-platform: [ android-arm, android-arm64, android-x64 ]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -94,8 +93,8 @@ jobs:
         with:
           name: irmagobridge-android
           path: android/irmagobridge/
-      - run: bundle exec fastlane android_build_app flavor:${{ matrix.flavor }} target_platform:${{ matrix.target-platform }}
+      - run: bundle exec fastlane android_build_app flavor:${{ matrix.flavor }}
       - uses: actions/upload-artifact@v3
         with:
-          name: app-${{ matrix.flavor }}-${{ matrix.target-platform }}
+          name: app-${{ matrix.flavor }}-android
           path: ./fastlane/build/*.apk

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -59,6 +59,24 @@ android {
             signingConfig signingConfigs.debug
         }
     }
+
+    // We use the React Native build numbering (with base 0x100000 and different multipliers per target platform)
+    android.applicationVariants.all { variant ->
+        variant.outputs.each { output ->
+            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
+            def abi = output.getFilter(com.android.build.OutputFile.ABI)
+            if (abi != null) {  // null for the universal-debug and universal-release variants
+                output.versionCodeOverride = versionCodes.get(abi) * 0x100000 + defaultConfig.versionCode
+            }
+        }
+    }
+
+    // We also include the universal APK for ad-hoc app test distribution.
+    splits {
+        abi {
+            universalApk true
+        }
+    }
 }
 
 flutter {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,9 +33,7 @@ end
 
 lane :android_build do |options|
     android_build_irmagobridge()
-    android_build_app(flavor: options[:flavor], target_platform: "android-arm", sentry_dsn: options[:sentry_dsn])
-    android_build_app(flavor: options[:flavor], target_platform: "android-arm64", sentry_dsn: options[:sentry_dsn])
-    android_build_app(flavor: options[:flavor], target_platform: "android-x64", sentry_dsn: options[:sentry_dsn])
+    android_build_app(flavor: options[:flavor], sentry_dsn: options[:sentry_dsn])
 end
 
 lane :android_build_irmagobridge do
@@ -52,28 +50,11 @@ lane :android_build_app do |options|
     version: commit[:commit_hash]
   )
 
-  # We use the React Native build numbering (with base 0x100000 and different multipliers per target platform)
-  # Flutter modifies the build number that we specify with its own build number base and target platform multiplier.
-  # Therefore, we have to correct this by subtracting the value that Flutter will add.
-  build_number = get_flutter_build_number()
-  case options[:target_platform]
-  when "android-arm"
-    build_number += 0x100000 - 1000
-  when "android-arm64"
-    build_number += 0x300000 - 2000
-  when "android-x64"
-    build_number += 0x400000 - 4000
-  else
-    raise "Unsupported target platform"
-  end
-
   Dir.chdir("..") do
     sh(
       "flutter", "build", "apk",
       "--split-per-abi",
       "--flavor", options[:flavor],
-      "--target-platform", options[:target_platform],
-      "--build-number", build_number.to_s,
       "--release"
     )
     sh("cp ./build/app/outputs/apk/#{options[:flavor]}/release/*.apk ./fastlane/build/")

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -79,7 +79,7 @@ Resigns the APKs in the `build` directory (so `fastlane/build` from the reposito
 [bundle exec] fastlane android_build flavor:<VALUE> sentry_dsn:<VALUE>
 ```
 
-Builds the Android APKs for the requested flavor. The APKs are split on target platform.
+Builds the Android APKs for the requested flavor. The APKs are split on target platform and a universal build is included.
 The unsigned Android APKs are written to the `build` directory (so `fastlane/build` from the repository's root).
 
 The `flavor` parameter accepts the values `alpha` or `beta`.
@@ -95,16 +95,14 @@ Builds the irmagobridge for Android.
 ### android_build_app
 
 ```sh
-[bundle exec] fastlane android_build_app flavor:<VALUE> target_platform:<VALUE> sentry_dsn:<VALUE>
+[bundle exec] fastlane android_build_app flavor:<VALUE> sentry_dsn:<VALUE>
 ```
 
-Builds the Android APK for the requested flavor and target platform. This action
-assumes the `android_build_irmagobridge` action has been run first.
-The unsigned Android APK is written to the `build` directory (so `fastlane/build` from the repository's root).
+Builds the Android APK for the requested flavor. The APKs are split on target platform and a universal build is included.
+This action assumes the `android_build_irmagobridge` action has been run first.
+The unsigned Android APKs are written to the `build` directory (so `fastlane/build` from the repository's root).
 
 The `flavor` parameter accepts the values `alpha` or `beta`.
-
-The `target_platform` parameter accepts the values `android-arm`, `android-arm64` or `android-x64`.
 
 ### ios_build
 


### PR DESCRIPTION
…al Android build

These changes prepare for moving the ux-2.0 branch to GitHub. For this, we need the pipeline to also produce universal APKs to make development builds available through Firebase App Distribution. 