### PR TITLE
Chore: add timeout in jobs that use ios_build_app lane with ipa export

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -105,6 +105,7 @@ jobs:
     strategy:
       matrix:
         flavor: [ alpha, beta ]
+    timeout-minutes: 20 # To prevent job runs to hang indefinitely. See comment in ios_build_app lane in the Fastfile.
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -172,6 +173,7 @@ jobs:
     needs: version-check
     if: needs.version-check.outputs.version-changed == 'true'
     environment: app-store-beta
+    timeout-minutes: 20 # To prevent job runs to hang indefinitely. See comment in ios_build_app lane in the Fastfile.
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -142,6 +142,7 @@ lane :ios_build_app do |options|
   # The 'flutter build ipa' command does not support changing the export method in Flutter 2.
   # Therefore, we use 'flutter build ios' for now with the --no-codesign option
   # and then we use Fastlane's build_ios_app action to sign and export the build.
+  # This work-around causes the lane to get stuck indefinitely sometimes.
   Dir.chdir("..") do
     sh("flutter", "build", "ios", "--release", "--no-codesign")
   end


### PR DESCRIPTION
To prevent a GitHub actions run to get stuck.
https://github.com/privacybydesign/irmamobile/actions/runs/3883084376/jobs/6624078743