### PR TITLE
Feat: support to let Fastlane fetch iOS provisioning profiles using the App Store Connect API

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -152,6 +152,7 @@ lane :ios_build_app do |options|
   end
 
   # When a provisioning profile is given, we ensure it is installed and selected in the project.
+  # If none is specified, we try to fetch the right provisioning profile using the Apple App Store Connect API.
   # Otherwise, we use the profile that is currently selected in XCode.
   if options[:provisioning_profile_path]
     provisioning_profile_path = File.absolute_path(options[:provisioning_profile_path])
@@ -161,6 +162,21 @@ lane :ios_build_app do |options|
     update_project_provisioning(
       xcodeproj: "ios/Runner.xcodeproj",
       profile: provisioning_profile_path
+    )
+  elsif options[:api_key_filepath]
+    api_key_filepath = File.absolute_path(options[:api_key_filepath])
+    api_key = app_store_connect_api_key(
+      key_id: options[:api_key_id],
+      issuer_id: options[:api_key_issuer_id],
+      key_filepath: api_key_filepath,
+      duration: 60
+    )
+    # Automatically fetch the provisioning profile matching the current distribution certificate and app identifier.
+    get_provisioning_profile(
+      adhoc: export_method == "ad-hoc",
+      app_identifier: app_identifier,
+      api_key: api_key,
+      readonly: true
     )
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -167,7 +167,7 @@ lane :ios_build_app do |options|
     api_key_filepath = File.absolute_path(options[:api_key_filepath])
     api_key = app_store_connect_api_key(
       key_id: options[:api_key_id],
-      issuer_id: options[:api_key_issuer_id],
+      issuer_id: options[:api_issuer_id],
       key_filepath: api_key_filepath,
       duration: 60
     )

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -17,7 +17,7 @@ For _fastlane_ installation instructions, see [Installing _fastlane_](https://do
 # Apple provisioning profiles
 The `ios_build_app` action needs the app's provisioning profile and the corresponding PKCS#12 certificate bundle.
 Therefore, these actions require the parameters `certificate_path`, `certificate_password` and either
-`api_key_filepath`, `api_key_id` and `api_key_issuer_id` (to download the provisioning
+`api_key_filepath`, `api_key_id` and `api_issuer_id` (to download the provisioning
 profile automatically using the App Store Connect API) or `provisioning_profile_path` (to manually pass it).
 In the latter case, if you later edit the provisioning profile in App Store Connect, then you need to update
 the provisioning profile manually.
@@ -158,7 +158,7 @@ Optionally, you can specify the following for extra functionality:
 
  - You can specify which provisioning profile should be used to provision the app. To automatically fetch
    the right provisioning profile from the App Store Connect API based on the requested flavor and iOS distribution certificate,
-   you can use the `api_key_filepath`, `api_key_id` and `api_key_issuer_id` parameters. More information about this
+   you can use the `api_key_filepath`, `api_key_id` and `api_issuer_id` parameters. More information about this
    mechanism can be found [here](https://developer.apple.com/documentation/appstoreconnectapi/creating_api_keys_for_app_store_connect_api).
    You can also supply a provisioning profile manually by using the `provisioning_profile_path` parameter.
    The `alpha` flavor expects an ad-hoc provisioning profile and the `beta` flavor an app-store provisioning profile.
@@ -169,7 +169,7 @@ fastlane directory as base (so `./fastlane` from the repository's root).
 More information on how to generate distribution certificates and provisioning profiles can be found [above](#apple-provisioning-profiles).
 
 ```sh
-[bundle exec] fastlane ios_build_app flavor:<VALUE> api_key_filepath:<VALUE> api_key_id:<VALUE> api_key_issuer_id:<VALUE> certificate_path:<VALUE> certificate_password:<VALUE>
+[bundle exec] fastlane ios_build_app flavor:<VALUE> api_key_filepath:<VALUE> api_key_id:<VALUE> api_issuer_id:<VALUE> certificate_path:<VALUE> certificate_password:<VALUE>
 [bundle exec] fastlane ios_build_app flavor:<VALUE> provisioning_profile_path:<VALUE> certificate_path:<VALUE> certificate_password:<VALUE>
 ```
 


### PR DESCRIPTION
If we often make ad-hoc builds then this enables us to update the device list in the provisioning profile without us having to manually update the provisioning profile in the CI.

If we want this, the following needs to be done:

Tasks
- [ ] Let build-app-ios-alpha GitHub actions job use this new feature
- [ ] Consider whether we want the build-app-ios-beta GitHub Actions job to use this too, for consistency