### PR TITLE
Chore: add support for building AAB artifacts for Android

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.gradle]
+indent_size = 4

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -105,6 +105,7 @@ jobs:
     strategy:
       matrix:
         flavor: [ alpha, beta ]
+        type: [ apk, appbundle ]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -119,12 +120,12 @@ jobs:
           path: android/irmagobridge/
       - name: Build app
         run: >
-          bundle exec fastlane android_build_app
+          bundle exec fastlane android_build_${{ matrix.type }}
           flavor:${{ matrix.flavor }}
           sentry_dsn:${{ secrets.SENTRY_DSN }}
       - uses: actions/upload-artifact@v3
         with:
-          name: app-alpha-android-${{ matrix.flavor }}
+          name: app-alpha-android-${{ matrix.flavor }}-${{ matrix.type }}
           path: ./fastlane/build/*.apk
   bundle-app-alpha:
     runs-on: ubuntu-latest
@@ -137,14 +138,22 @@ jobs:
         with:
           name: app-alpha-ios
       # Check the comment above in the build-app-android-alpha job spec why the beta is also present here.
-      - name: Download app-alpha-android-alpha artifact
+      - name: Download app-alpha-android-alpha-apk artifact
         uses: actions/download-artifact@v3
         with:
-          name: app-alpha-android-alpha
-      - name: Download app-alpha-android-beta artifact
+          name: app-alpha-android-alpha-apk
+      - name: Download app-alpha-android-alpha-appbundle artifact
         uses: actions/download-artifact@v3
         with:
-          name: app-alpha-android-beta
+          name: app-alpha-android-alpha-appbundle
+      - name: Download app-alpha-android-beta-apk artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: app-alpha-android-beta-apk
+      - name: Download app-alpha-android-beta-appbundle artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: app-alpha-android-beta-appbundle
       - name: Bundle all artifacts
         uses: actions/upload-artifact@v3
         with:
@@ -223,7 +232,7 @@ jobs:
           path: android/irmagobridge/
       - name: Build app
         run: >
-          bundle exec fastlane android_build_app
+          bundle exec fastlane android_build_appbundle
           flavor:beta
           sentry_dsn:${{ secrets.SENTRY_DSN }}
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -98,7 +98,7 @@ jobs:
     needs:
       - unit-test
       - build-irmagobridge-android
-    environment: ad-hoc-alpha
+    environment: android-alpha
     # For now, we also build the beta flavor using the alpha secrets to enable ad-hoc distribution of the
     # beta flavor Android app. This is needed, because the irma-frontend-packages use the app identifier of the
     # beta flavor Android app in the intent:// links.
@@ -118,11 +118,23 @@ jobs:
         with:
           name: irmagobridge-android
           path: android/irmagobridge/
+      - name: Decode binary environment secrets
+        env:
+          ANDROID_SIGNING_KEYSTORE: ${{ secrets.ANDROID_SIGNING_KEYSTORE }}
+        run: |
+          mkdir -p ./fastlane/profiles
+          echo $ANDROID_SIGNING_KEYSTORE | base64 --decode > ./fastlane/profiles/keystore.jks
       - name: Build app
+        env:
+          ANDROID_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEYSTORE_PASSWORD }}
         run: >
           bundle exec fastlane android_build_${{ matrix.type }}
           flavor:${{ matrix.flavor }}
           sentry_dsn:${{ secrets.SENTRY_DSN }}
+          keystore_path:profiles/keystore.jks
+          key_alias:android-signing-alpha
+          keystore_password:$ANDROID_SIGNING_KEYSTORE_PASSWORD
+          key_password:$ANDROID_SIGNING_KEYSTORE_PASSWORD
       - uses: actions/upload-artifact@v3
         with:
           name: app-alpha-android-${{ matrix.flavor }}-${{ matrix.type }}
@@ -217,7 +229,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: version-check
     if: needs.version-check.outputs.version-changed == 'true'
-    environment: app-store-beta
+    environment: android-beta
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -230,11 +242,23 @@ jobs:
         with:
           name: irmagobridge-android
           path: android/irmagobridge/
+      - name: Decode binary environment secrets
+        env:
+          ANDROID_SIGNING_KEYSTORE: ${{ secrets.ANDROID_SIGNING_KEYSTORE }}
+        run: |
+          mkdir -p ./fastlane/profiles
+          echo $ANDROID_SIGNING_KEYSTORE | base64 --decode > ./fastlane/profiles/keystore.jks
       - name: Build app
+        env:
+          ANDROID_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEYSTORE_PASSWORD }}
         run: >
           bundle exec fastlane android_build_appbundle
           flavor:beta
           sentry_dsn:${{ secrets.SENTRY_DSN }}
+          keystore_path:profiles/keystore.jks
+          key_alias:android-play-store-upload-key
+          keystore_password:$ANDROID_SIGNING_KEYSTORE_PASSWORD
+          key_password:$ANDROID_SIGNING_KEYSTORE_PASSWORD
       - uses: actions/upload-artifact@v3
         with:
           name: app-beta-android

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -125,16 +125,14 @@ jobs:
           mkdir -p ./fastlane/profiles
           echo $ANDROID_SIGNING_KEYSTORE | base64 --decode > ./fastlane/profiles/keystore.jks
       - name: Build app
-        env:
-          ANDROID_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEYSTORE_PASSWORD }}
         run: >
           bundle exec fastlane android_build_${{ matrix.type }}
           flavor:${{ matrix.flavor }}
           sentry_dsn:${{ secrets.SENTRY_DSN }}
           keystore_path:profiles/keystore.jks
           key_alias:android-signing-alpha
-          keystore_password:$ANDROID_SIGNING_KEYSTORE_PASSWORD
-          key_password:$ANDROID_SIGNING_KEYSTORE_PASSWORD
+          keystore_password:${{ secrets.ANDROID_SIGNING_KEYSTORE_PASSWORD }}
+          key_password:${{ secrets.ANDROID_SIGNING_KEYSTORE_PASSWORD }}
       - uses: actions/upload-artifact@v3
         with:
           name: app-alpha-android-${{ matrix.flavor }}-${{ matrix.type }}
@@ -249,16 +247,14 @@ jobs:
           mkdir -p ./fastlane/profiles
           echo $ANDROID_SIGNING_KEYSTORE | base64 --decode > ./fastlane/profiles/keystore.jks
       - name: Build app
-        env:
-          ANDROID_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_SIGNING_KEYSTORE_PASSWORD }}
         run: >
           bundle exec fastlane android_build_appbundle
           flavor:beta
           sentry_dsn:${{ secrets.SENTRY_DSN }}
           keystore_path:profiles/keystore.jks
           key_alias:android-play-store-upload-key
-          keystore_password:$ANDROID_SIGNING_KEYSTORE_PASSWORD
-          key_password:$ANDROID_SIGNING_KEYSTORE_PASSWORD
+          keystore_password:${{ secrets.ANDROID_SIGNING_KEYSTORE_PASSWORD }}
+          key_password:${{ secrets.ANDROID_SIGNING_KEYSTORE_PASSWORD }}
       - uses: actions/upload-artifact@v3
         with:
           name: app-beta-android

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -94,7 +94,22 @@ jobs:
         with:
           name: irmagobridge-android
           path: android/irmagobridge/
-      - run: bundle exec fastlane android_build_${{ matrix.type }} flavor:${{ matrix.flavor }}
+      - name: Decode binary environment secrets
+        env:
+          ANDROID_DEVELOPMENT_SIGNING_KEYSTORE: ${{ secrets.ANDROID_DEVELOPMENT_SIGNING_KEYSTORE }}
+        run: |
+          mkdir -p ./fastlane/profiles
+          echo $ANDROID_DEVELOPMENT_SIGNING_KEYSTORE | base64 --decode > ./fastlane/profiles/keystore.jks
+      - name: Build
+        env:
+          ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD }}
+        run: >
+          bundle exec fastlane android_build_${{ matrix.type }}
+          flavor:${{ matrix.flavor }}
+          keystore_path:profiles/keystore.jks
+          key_alias:android-signing-development
+          keystore_password:$ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD
+          key_password:$ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD
       - name:
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -110,8 +110,7 @@ jobs:
           key_alias:android-signing-development
           keystore_password:$ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD
           key_password:$ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD
-      - name:
-        uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v3
         with:
           name: app-${{ matrix.flavor }}-android-${{ matrix.type }}
           path: ./fastlane/build/*

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -81,6 +81,7 @@ jobs:
     strategy:
       matrix:
         flavor: [ alpha, beta ]
+        type: [ apk, appbundle ]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -93,11 +94,12 @@ jobs:
         with:
           name: irmagobridge-android
           path: android/irmagobridge/
-      - run: bundle exec fastlane android_build_app flavor:${{ matrix.flavor }}
-      - uses: actions/upload-artifact@v3
+      - run: bundle exec fastlane android_build_${{ matrix.type }} flavor:${{ matrix.flavor }}
+      - name:
+        uses: actions/upload-artifact@v3
         with:
-          name: app-${{ matrix.flavor }}-android
-          path: ./fastlane/build/*.apk
+          name: app-${{ matrix.flavor }}-android-${{ matrix.type }}
+          path: ./fastlane/build/*
   build-integration-test-android:
     runs-on: ubuntu-latest
     needs: build-irmagobridge-android

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -101,15 +101,13 @@ jobs:
           mkdir -p ./fastlane/profiles
           echo $ANDROID_DEVELOPMENT_SIGNING_KEYSTORE | base64 --decode > ./fastlane/profiles/keystore.jks
       - name: Build
-        env:
-          ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD }}
         run: >
           bundle exec fastlane android_build_${{ matrix.type }}
           flavor:${{ matrix.flavor }}
           keystore_path:profiles/keystore.jks
           key_alias:android-signing-development
-          keystore_password:$ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD
-          key_password:$ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD
+          keystore_password:${{ secrets.ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD }}
+          key_password:${{ secrets.ANDROID_DEVELOPMENT_SIGNING_KEYSTORE_PASSWORD }}
       - uses: actions/upload-artifact@v3
         with:
           name: app-${{ matrix.flavor }}-android-${{ matrix.type }}

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -25,7 +25,7 @@ apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {
-    compileSdkVersion 31
+    compileSdkVersion 33
 
     lintOptions {
         disable 'InvalidPackage'
@@ -52,29 +52,43 @@ android {
         }
     }
 
-    buildTypes {
-        release {
-            // Sign here with dummy credentials, fastlane will do the actual
-            // signing using a resign
-            signingConfig signingConfigs.debug
-        }
-    }
-
-    // We use the React Native build numbering (with base 0x100000 and different multipliers per target platform)
-    android.applicationVariants.all { variant ->
-        variant.outputs.each { output ->
-            def versionCodes = ["armeabi-v7a": 1, "x86": 2, "arm64-v8a": 3, "x86_64": 4]
-            def abi = output.getFilter(com.android.build.OutputFile.ABI)
-            if (abi != null) {  // null for the universal-debug and universal-release variants
-                output.versionCodeOverride = versionCodes.get(abi) * 0x100000 + defaultConfig.versionCode
+    signingConfigs {
+        if (project.hasProperty("keyStoreFile")) {
+            release {
+                storeFile file(project.property("keyStoreFile"))
+                storePassword project.property("keyStorePassword")
+                keyAlias project.property("keyAlias")
+                keyPassword project.property("keyPassword")
             }
         }
     }
 
-    // We also include the universal APK for ad-hoc app test distribution.
-    splits {
-        abi {
-            universalApk true
+    buildTypes {
+        release {
+            if (project.hasProperty("keyStoreFile")) {
+                signingConfig signingConfigs.release
+            } else {
+                // For testing purposes we sign with dummy credentials if no key properties are given.
+                signingConfig signingConfigs.debug
+            }
+        }
+    }
+
+    bundle {
+        // Store archive and code transparency cannot be combined yet.
+        // https://stackoverflow.com/questions/74275816/code-verification-error-when-uploading-aab-files-added-after-transparency-meta
+        storeArchive {
+            enable = false
+        }
+        if (project.hasProperty("keyStoreFile")) {
+            codeTransparency {
+                signing {
+                    storeFile file(project.property("keyStoreFile"))
+                    storePassword project.property("keyStorePassword")
+                    keyAlias project.property("keyAlias")
+                    keyPassword project.property("keyPassword")
+                }
+            }
         }
     }
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,18 +1,18 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.0.1'
+        classpath 'com.android.tools.build:gradle:7.4.0'
     }
 }
 
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
-#Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6-bin.zip
+distributionSha256Sum=7ba68c54029790ab444b39d7e293d3236b2632631fb5f2e012bb28b4ff669e4b
+networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
-distributionSha256Sum=13bf8d3cf8eeeb5770d19741a59bde9bd966dd78d17f1bbad787a05ef19d1c2d

--- a/ci_scripts/install_android_sdk.sh
+++ b/ci_scripts/install_android_sdk.sh
@@ -49,18 +49,20 @@ set +o pipefail
 yes | sdkmanager --sdk_root="$ANDROID_HOME" --licenses > /dev/null
 set -o pipefail
 
-# Flutter 2 needs Android SDK platform 28, 29, 30 and 31 and build-tools 28 and 30. We pre-install them
-# to prevent that Flutter downloads them on every app build.
+# We pre-install some Android SDKs to prevent that Flutter downloads them on every app build.
+# Which versions we need is dependent on the our target Android SDK and the target Android SDK of our dependencies.
+# There is no convenient way to determine this in Flutter yet. Therefore, we hardcode some versions here.
+# Issue: https://github.com/flutter/flutter/issues/63533
 sdkmanager --sdk_root="$ANDROID_HOME" \
-  "platform-tools" \
+  "cmdline-tools;latest" \
   "ndk;$ANDROID_NDK_VERSION" \
   "cmake;3.10.2.4988404" \
   "platforms;android-28" \
   "platforms;android-29" \
   "platforms;android-30" \
   "platforms;android-31" \
-  "build-tools;28.0.3" \
-  "build-tools;30.0.2"
+  "platforms;android-33" \
+  "build-tools;30.0.3"
 
 # Ensure that right NDK version is selected.
 ln -s "$ANDROID_HOME/ndk/$ANDROID_NDK_VERSION" "$ANDROID_HOME/ndk-bundle"

--- a/ci_scripts/install_android_sdk.sh
+++ b/ci_scripts/install_android_sdk.sh
@@ -50,7 +50,7 @@ yes | sdkmanager --sdk_root="$ANDROID_HOME" --licenses > /dev/null
 set -o pipefail
 
 # We pre-install some Android SDKs to prevent that Flutter downloads them on every app build.
-# Which versions we need is dependent on the our target Android SDK and the target Android SDK of our dependencies.
+# Which versions we need is dependent on our target Android SDK and the target Android SDK of our dependencies.
 # There is no convenient way to determine this in Flutter yet. Therefore, we hardcode some versions here.
 # Issue: https://github.com/flutter/flutter/issues/63533
 sdkmanager --sdk_root="$ANDROID_HOME" \

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -75,24 +75,23 @@ private_lane :android_build_app do |options|
     version: commit[:commit_hash]
   )
 
-  command = [
-    "flutter", "build", options[:build_type],
-    "--flavor", options[:flavor],
-    "--release"
-  ]
+  # In Fastlane it's not possible to mask secrets in the command, while showing the shell output of the command.
+  # Therefore, we use environment variables to hide parameter values.
+  puts "In the following command, parameter values are hidden using environment variables."
+  cmd = "flutter build $FASTLANE_BUILD_TYPE --flavor $FASTLANE_FLAVOR --release"
+  ENV["FASTLANE_BUILD_TYPE"] = options[:build_type]
+  ENV["FASTLANE_FLAVOR"] = options[:flavor]
   if options[:keystore_path]
-    keystore_path = File.absolute_path(options[:keystore_path])
-    command += [
-      "-PkeyStoreFile=#{keystore_path}",
-      "-PkeyStorePassword=#{options[:keystore_password]}",
-      "-PkeyAlias=#{options[:key_alias]}",
-      "-PkeyPassword=#{options[:key_password]}"
-    ]
+    ENV["FASTLANE_KEYSTORE_PATH"] = File.absolute_path(options[:keystore_path])
+    ENV["FASTLANE_KEYSTORE_PASSWORD"] = options[:keystore_password]
+    ENV["FASTLANE_KEY_ALIAS"] = options[:key_alias]
+    ENV["FASTLANE_KEY_PASSWORD"] = options[:key_password]
+    cmd += " -PkeyStoreFile=$FASTLANE_KEYSTORE_PATH -PkeyStorePassword=$FASTLANE_KEYSTORE_PASSWORD"
+    cmd += " -PkeyAlias=$FASTLANE_KEY_ALIAS -PkeyPassword=$FASTLANE_KEY_PASSWORD"
   end
 
   Dir.chdir("..") do
-    # Hide logging to mask passwords
-    sh(*command, log: false)
+    sh(cmd)
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,21 +19,16 @@ lane :unit_test do
   end
 end
 
-lane :android_resign do |options|
-  apks = Dir["build/app-#{options[:flavor]}-*.apk"]
-  apks.each do |apk|
-    sh("apksigner", "sign",
-      "--ks", options[:keystore_path],
-      "--ks-key-alias", options[:key_alias],
-      "--ks-pass", "pass:"+options[:keystore_password],
-      "--key-pass", "pass:"+options[:key_password],
-      apk)
-  end
-end
-
 lane :android_build do |options|
-    android_build_irmagobridge()
-    android_build_app(flavor: options[:flavor], sentry_dsn: options[:sentry_dsn])
+  android_build_irmagobridge()
+  android_build_appbundle(
+    flavor: options[:flavor],
+    sentry_dsn: options[:sentry_dsn],
+    keystore_path: options[:keystore_path],
+    keystore_password: options[:keystore_password],
+    key_alias: options[:key_alias],
+    key_password: options[:key_password]
+  )
 end
 
 lane :android_build_irmagobridge do
@@ -42,7 +37,37 @@ lane :android_build_irmagobridge do
   end
 end
 
-lane :android_build_app do |options|
+lane :android_build_universal_apk do |options|
+  android_build_app(
+    build_type: "apk",
+    flavor: options[:flavor],
+    sentry_dsn: options[:sentry_dsn],
+    keystore_path: options[:keystore_path],
+    keystore_password: options[:keystore_password],
+    key_alias: options[:key_alias],
+    key_password: options[:key_password]
+  )
+  Dir.chdir("..") do
+    sh("cp ./build/app/outputs/apk/#{options[:flavor]}/release/*.apk ./fastlane/build/")
+  end
+end
+
+lane :android_build_appbundle do |options|
+  android_build_app(
+    build_type: "appbundle",
+    flavor: options[:flavor],
+    sentry_dsn: options[:sentry_dsn],
+    keystore_path: options[:keystore_path],
+    keystore_password: options[:keystore_password],
+    key_alias: options[:key_alias],
+    key_password: options[:key_password]
+  )
+  Dir.chdir("..") do
+    sh("cp ./build/app/outputs/bundle/#{options[:flavor]}Release/*.aab ./fastlane/build/")
+  end
+end
+
+private_lane :android_build_app do |options|
   update_schemes()
   commit = last_git_commit()
   write_sentrydata(
@@ -50,14 +75,24 @@ lane :android_build_app do |options|
     version: commit[:commit_hash]
   )
 
+  command = [
+    "flutter", "build", options[:build_type],
+    "--flavor", options[:flavor],
+    "--release"
+  ]
+  if options[:keystore_path]
+    keystore_path = File.absolute_path(options[:keystore_path])
+    command += [
+      "-PkeyStoreFile=#{keystore_path}",
+      "-PkeyStorePassword=#{options[:keystore_password]}",
+      "-PkeyAlias=#{options[:key_alias]}",
+      "-PkeyPassword=#{options[:key_password]}"
+    ]
+  end
+
   Dir.chdir("..") do
-    sh(
-      "flutter", "build", "apk",
-      "--split-per-abi",
-      "--flavor", options[:flavor],
-      "--release"
-    )
-    sh("cp ./build/app/outputs/apk/#{options[:flavor]}/release/*.apk ./fastlane/build/")
+    # Hide logging to mask passwords
+    sh(*command, log: false)
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -37,7 +37,7 @@ lane :android_build_irmagobridge do
   end
 end
 
-lane :android_build_universal_apk do |options|
+lane :android_build_apk do |options|
   android_build_app(
     build_type: "apk",
     flavor: options[:flavor],

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -59,7 +59,7 @@ and `key_password` parameters.
 Below we describe how you can generate a Java Keystore for signing.
 
  1. Specify a key name, i.e. `KEY_ALIAS=upload-key`
- 2. Run `keytool -genkey -alias $KEY_ALIAS -keyalg RSA -keystore $KEY_ALIAS.jks -keysize 4096`
+ 2. Run `keytool -genkey -alias $KEY_ALIAS -keyalg RSA -keystore $KEY_ALIAS.jks -keysize 4096 -validity 10000`
  3. If you need the certificate to upload to Google, you can generate one in the following way:
     `keytool -export -rfc -keystore $KEY_ALIAS.jks -alias $KEY_ALIAS -file $KEY_ALIAS.pem`
  4. In case you need to upload the assets to a secret vault, then you need to encode the files with base64,

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -61,7 +61,7 @@ Below we describe how you can generate a Java Keystore for signing.
  1. Specify a key name, i.e. `KEY_ALIAS=upload-key`
  2. Run `keytool -genkey -alias $KEY_ALIAS -keyalg RSA -keystore $KEY_ALIAS.jks -keysize 4096`
  3. If you need the certificate to upload to Google, you can generate one in the following way:
-    `keytool -export -rfc -keystore $KEY_ALIAS.jks -alias $KEY_ALIAS -file $KEYNAME.pem`
+    `keytool -export -rfc -keystore $KEY_ALIAS.jks -alias $KEY_ALIAS -file $KEY_ALIAS.pem`
  4. In case you need to upload the assets to a secret vault, then you need to encode the files with base64,
     i.e. `cat $KEY_ALIAS.jks | base64 > $KEY_ALIAS.jks.base64`
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -51,7 +51,7 @@ Uploading can be done using [Transporter for MacOS](https://apps.apple.com/us/ap
 The artifacts produced by the `android_build_apk` and the `android_build_appbundle` actions need to be signed in order
 to distribute them. For the Google Play Store, you need an app bundle signed with the right upload key.
 The corresponding certificate needs to be registered with Google. This upload key is also used as signing key for
-Android Code Transparency. For ad-hoc APKs, artifact are signed using regular APK signing.
+Android Code Transparency. For ad-hoc APKs, artifacts are signed using regular APK signing.
 The `android_build_apk` and the `android_build_appbundle` actions have built-in support for signing.
 The key should be given as Java Keystore and can be passed using the `keystore_path`, `key_alias`, `keystore_password`
 and `key_password` parameters.
@@ -60,7 +60,7 @@ Below we describe how you can generate a Java Keystore for signing.
 
  1. Specify a key name, i.e. `KEY_ALIAS=upload-key`
  2. Run `keytool -genkey -alias $KEY_ALIAS -keyalg RSA -keystore $KEY_ALIAS.jks -keysize 4096 -validity 10000`
- 3. If you need the certificate to upload to Google, you can generate one in the following way:
+ 3. If you need to register the key as upload key to Google Play, you can generate the certificate in the following way:
     `keytool -export -rfc -keystore $KEY_ALIAS.jks -alias $KEY_ALIAS -file $KEY_ALIAS.pem`
  4. In case you need to upload the assets to a secret vault, then you need to encode the files with base64,
     i.e. `cat $KEY_ALIAS.jks | base64 > $KEY_ALIAS.jks.base64`

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -65,22 +65,21 @@ Checks the code quality of the project.
 
 Checks whether all unit tests pass.
 
-### android_resign
-
-```sh
-[bundle exec] fastlane android_resign flavor:<VALUE> keystore_path:<VALUE> key_alias:<VALUE> keystore_password:<VALUE> key_password:<VALUE>
-```
-
-Resigns the APKs in the `build` directory (so `fastlane/build` from the repository's root) for the requested flavor.
-
 ### android_build
 
 ```sh
 [bundle exec] fastlane android_build flavor:<VALUE> sentry_dsn:<VALUE>
 ```
 
-Builds the Android APKs for the requested flavor. The APKs are split on target platform and a universal build is included.
-The unsigned Android APKs are written to the `build` directory (so `fastlane/build` from the repository's root).
+Builds the Android AAB for the requested flavor.
+The AAB is written to the `build` directory (so `fastlane/build` from the repository's root).
+
+Optionally, you can specify the key properties of the upload key that should be used to sign the build.
+This key is also used to sign the app bundle's code transparency file.
+
+```sh
+[bundle exec] fastlane android_build flavor:<VALUE> sentry_dsn:<VALUE> keystore_path:<VALUE> key_alias:<VALUE> keystore_password:<VALUE> key_password:<VALUE>
+```
 
 The `flavor` parameter accepts the values `alpha` or `beta`.
 
@@ -92,15 +91,42 @@ The `flavor` parameter accepts the values `alpha` or `beta`.
 
 Builds the irmagobridge for Android.
 
-### android_build_app
+### android_build_universal_apk
 
 ```sh
-[bundle exec] fastlane android_build_app flavor:<VALUE> sentry_dsn:<VALUE>
+[bundle exec] fastlane android_build_universal_apk flavor:<VALUE> sentry_dsn:<VALUE>
 ```
 
-Builds the Android APK for the requested flavor. The APKs are split on target platform and a universal build is included.
+Builds the Android APK for the requested flavor. Only a universal build is included. Check the `android_build`
+or the `android_build_appbundle` action if you want to build for the Google Play Store.
 This action assumes the `android_build_irmagobridge` action has been run first.
-The unsigned Android APKs are written to the `build` directory (so `fastlane/build` from the repository's root).
+The Android APK is written to the `build` directory (so `fastlane/build` from the repository's root).
+
+Optionally, you can specify the key properties of the signing key that should be used.
+
+```sh
+[bundle exec] fastlane android_build_universal_apk flavor:<VALUE> sentry_dsn:<VALUE> keystore_path:<VALUE> key_alias:<VALUE> keystore_password:<VALUE> key_password:<VALUE>
+```
+
+The `flavor` parameter accepts the values `alpha` or `beta`.
+
+### android_build_appbundle
+
+```sh
+[bundle exec] fastlane android_build_appbundle flavor:<VALUE> sentry_dsn:<VALUE>
+```
+
+Builds the Android AAB for the requested flavor.
+This action assumes the `android_build_irmagobridge` action has been run first.
+Check the `android_build` action if you want to do a full build.
+The AAB is written to the `build` directory (so `fastlane/build` from the repository's root).
+
+Optionally, you can specify the key properties of the upload key that should be used to sign the build.
+This key is also used to sign the app bundle's code transparency file.
+
+```sh
+[bundle exec] fastlane android_build_appbundle flavor:<VALUE> sentry_dsn:<VALUE> keystore_path:<VALUE> key_alias:<VALUE> keystore_password:<VALUE> key_password:<VALUE>
+```
 
 The `flavor` parameter accepts the values `alpha` or `beta`.
 

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -47,6 +47,24 @@ Note: provisioning profiles can only be used to sign app builds. To upload the b
 you additionally need your personal App Store Connect account with the right permissions.
 Uploading can be done using [Transporter for MacOS](https://apps.apple.com/us/app/transporter/id1450874784?mt=12).
 
+# Android signing/upload keys
+The artifacts produced by the `android_build_apk` and the `android_build_appbundle` actions need to be signed in order
+to distribute them. For the Google Play Store, you need an app bundle signed with the right upload key.
+The corresponding certificate needs to be registered with Google. This upload key is also used as signing key for
+Android Code Transparency. For ad-hoc APKs, artifact are signed using regular APK signing.
+The `android_build_apk` and the `android_build_appbundle` actions have built-in support for signing.
+The key should be given as Java Keystore and can be passed using the `keystore_path`, `key_alias`, `keystore_password`
+and `key_password` parameters.
+
+Below we describe how you can generate a Java Keystore for signing.
+
+ 1. Specify a key name, i.e. `KEY_ALIAS=upload-key`
+ 2. Run `keytool -genkey -alias $KEY_ALIAS -keyalg RSA -keystore $KEY_ALIAS.jks -keysize 4096`
+ 3. If you need the certificate to upload to Google, you can generate one in the following way:
+    `keytool -export -rfc -keystore $KEY_ALIAS.jks -alias $KEY_ALIAS -file $KEYNAME.pem`
+ 4. In case you need to upload the assets to a secret vault, then you need to encode the files with base64,
+    i.e. `cat $KEY_ALIAS.jks | base64 > $KEY_ALIAS.jks.base64`
+
 # Available Actions
 
 ### lint

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -91,10 +91,10 @@ The `flavor` parameter accepts the values `alpha` or `beta`.
 
 Builds the irmagobridge for Android.
 
-### android_build_universal_apk
+### android_build_apk
 
 ```sh
-[bundle exec] fastlane android_build_universal_apk flavor:<VALUE> sentry_dsn:<VALUE>
+[bundle exec] fastlane android_build_apk flavor:<VALUE> sentry_dsn:<VALUE>
 ```
 
 Builds the Android APK for the requested flavor. Only a universal build is included. Check the `android_build`
@@ -105,7 +105,7 @@ The Android APK is written to the `build` directory (so `fastlane/build` from th
 Optionally, you can specify the key properties of the signing key that should be used.
 
 ```sh
-[bundle exec] fastlane android_build_universal_apk flavor:<VALUE> sentry_dsn:<VALUE> keystore_path:<VALUE> key_alias:<VALUE> keystore_password:<VALUE> key_password:<VALUE>
+[bundle exec] fastlane android_build_apk flavor:<VALUE> sentry_dsn:<VALUE> keystore_path:<VALUE> key_alias:<VALUE> keystore_password:<VALUE> key_password:<VALUE>
 ```
 
 The `flavor` parameter accepts the values `alpha` or `beta`.

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
-  - DTTJailbreakDetection (0.4.0)
   - Flutter (1.0.0)
   - flutter_jailbreak_detection (1.0.0):
-    - DTTJailbreakDetection
     - Flutter
+    - IOSSecuritySuite
   - flutter_privacy_screen (0.0.1):
     - Flutter
   - integration_test (0.0.1):
     - Flutter
+  - IOSSecuritySuite (1.9.5)
   - MTBBarcodeScanner (5.0.11)
   - package_info (0.0.1):
     - Flutter
@@ -16,13 +16,11 @@ PODS:
   - qr_code_scanner (0.2.0):
     - Flutter
     - MTBBarcodeScanner
-  - Sentry (7.2.8):
-    - Sentry/Core (= 7.2.8)
-  - Sentry/Core (7.2.8)
+  - Sentry/HybridSDK (7.31.5)
   - sentry_flutter (0.0.1):
     - Flutter
     - FlutterMacOS
-    - Sentry (~> 7.2.7)
+    - Sentry/HybridSDK (= 7.31.5)
   - share (0.0.1):
     - Flutter
   - shared_preferences (0.0.1):
@@ -45,7 +43,7 @@ DEPENDENCIES:
 
 SPEC REPOS:
   trunk:
-    - DTTJailbreakDetection
+    - IOSSecuritySuite
     - MTBBarcodeScanner
     - Sentry
 
@@ -74,21 +72,21 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/url_launcher/ios"
 
 SPEC CHECKSUMS:
-  DTTJailbreakDetection: 5e356c5badc17995f65a83ed9483f787a0057b71
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
-  flutter_jailbreak_detection: f6c01e4bc73641c6b69c5112e50301240601abb4
+  flutter_jailbreak_detection: c5bf66ff6c0c4230769b6ba0bd63eb6ac4148a76
   flutter_privacy_screen: 60e2b67bb00f0bba6ccfbdf8c5ad353ef928fb68
   integration_test: a1e7d09bd98eca2fc37aefd79d4f41ad37bdbbe5
+  IOSSecuritySuite: 1c04c80a45c9f8899909c70854c05e992acc34aa
   MTBBarcodeScanner: f453b33c4b7dfe545d8c6484ed744d55671788cb
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
   package_info_plus: 6c92f08e1f853dc01228d6f553146438dafcd14e
   qr_code_scanner: bb67d64904c3b9658ada8c402e8b4d406d5d796e
-  Sentry: f315ca2086f72f825b1b2e0cdebe81b44131cbd2
-  sentry_flutter: 28e1e38fe797d3e5d766c596324834fed599bc0f
+  Sentry: 4c9babff9034785067c896fd580b1f7de44da020
+  sentry_flutter: b10ae7a5ddcbc7f04648eeb2672b5747230172f1
   share: 0b2c3e82132f5888bccca3351c504d0003b3b410
   shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -270,7 +270,7 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh",
-				"${BUILT_PRODUCTS_DIR}/DTTJailbreakDetection/DTTJailbreakDetection.framework",
+				"${BUILT_PRODUCTS_DIR}/IOSSecuritySuite/IOSSecuritySuite.framework",
 				"${BUILT_PRODUCTS_DIR}/MTBBarcodeScanner/MTBBarcodeScanner.framework",
 				"${BUILT_PRODUCTS_DIR}/Sentry/Sentry.framework",
 				"${BUILT_PRODUCTS_DIR}/flutter_jailbreak_detection/flutter_jailbreak_detection.framework",
@@ -286,7 +286,7 @@
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
-				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/DTTJailbreakDetection.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/IOSSecuritySuite.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/MTBBarcodeScanner.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/Sentry.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/flutter_jailbreak_detection.framework",

--- a/lib/src/sentry/sentry.dart
+++ b/lib/src/sentry/sentry.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/foundation.dart';
 import 'package:irmamobile/sentry_dsn.dart';
 import 'package:irmamobile/src/data/irma_preferences.dart';
+import 'package:irmamobile/src/sentry/stub_platform_checker.dart';
 import 'package:package_info/package_info.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -19,11 +21,13 @@ Future<void> initSentry({required IrmaPreferences preferences}) async {
           options.release = release;
           options.dsn = dsn;
           options.enableNativeCrashHandling = reportErrors;
+          // As noted in the docs of enableNativeCrashHandling, platform checking does not work on iOS when
+          // native crash handling is disabled. Therefore, we add a fallback implementation.
+          if (!options.enableNativeCrashHandling && Platform.isIOS) options.platformChecker = StubPlatformChecker();
           // In the privacy policy we only mention error events, so we don't send the session health information.
           options.enableAutoSessionTracking = false;
         },
       );
-      Sentry.configureScope((scope) => scope.setTag('git', version));
       if (!completer.isCompleted) completer.complete();
     });
     await completer.future;

--- a/lib/src/sentry/stub_platform_checker.dart
+++ b/lib/src/sentry/stub_platform_checker.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/foundation.dart';
+import 'package:sentry_flutter/sentry_flutter.dart';
+
+/// Stub implementation of PlatformChecker that does not rely on native integration.
+/// This is useful for users that disabled automatic error reporting on iOS, but do want to manually report errors.
+class StubPlatformChecker extends PlatformChecker {
+  @override
+  bool get hasNativeIntegration => false;
+
+  @override
+  bool isDebugMode() => kDebugMode;
+
+  @override
+  bool isProfileMode() => kProfileMode;
+
+  @override
+  bool isReleaseMode() => kReleaseMode;
+
+  @override
+  bool get isWeb => false;
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -255,7 +255,7 @@ packages:
       name: flutter_jailbreak_detection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.10.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
@@ -653,14 +653,14 @@ packages:
       name: sentry
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.19.0"
   sentry_flutter:
     dependency: "direct main"
     description:
       name: sentry_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.0"
+    version: "6.19.0"
   share:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: irmamobile
 description: IRMA Authentication
-version: 6.4.0+147
+version: 6.4.0+4194452
 
 environment:
   sdk: ">=2.13.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   flutter_localizations:
     sdk: flutter
 
-  sentry_flutter: ^6.0.0
+  sentry_flutter: ^6.19.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -36,7 +36,7 @@ dependencies:
   async: ^2.6.1
   streaming_shared_preferences: ^2.0.0
   path_drawing: ^0.5.1
-  flutter_jailbreak_detection: ^1.8.0
+  flutter_jailbreak_detection: ^1.10.0
   visibility_detector: ^0.2.2
   quiver: ^3.0.1
   flutter_privacy_screen:


### PR DESCRIPTION
If we use AAB files, all CPU architectures are bundled in one artifact. When delivering APKs, the previous build number was multiplied by a constant to make sure the build numbers don't clash. I removed multiplying the build number from the build.gradle and replaced it by increasing the build number in the pubspec.yaml to the highest build number we currently use + 1.

To enable code transparency, I had to migrate to the Android Gradle plugin 7.4. Due to this I had to bump some other packages as well.

When the build numbers are equal, we cannot rely on the dist number to see whether an error in Sentry comes from iOS or Android. Therefore, I added a stub to ensure that we always receive the basic platform information.

Tasks:
- [x] Use freshly generated signing keys instead of using Android debug signing keys for alpha and beta builds in GitHub actions