### PR TITLE
chore: update native_device_orientation

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,7 +476,7 @@ packages:
       name: native_device_orientation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.4"
   nested:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   package_info: ^2.0.2
   collection: ^1.15.0
   mobile_scanner: ^1.1.2
-  native_device_orientation: ^1.0.0 # TODO: Remove this package once mobile_scanner supports landscape
+  native_device_orientation: ^1.1.4
   share: ^2.0.4
   intl: ^0.17.0
   flutter_markdown: ^0.6.6


### PR DESCRIPTION
The package sometimes throws a PlatformException while closing the method channel stream. Let's try updating it to the newest version to see if this problem remains. 