### PR TITLE
Chore: use flutter build ipa to build iOS app

### DIFF
--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -9,28 +9,8 @@ on:
 concurrency: ${{ github.ref }}
 
 jobs:
-  # We make sure that lint succeeds before we start any other job to
-  # prevent that the setup-build-environment action runs in parallel.
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build-environment
-      - run: bundle exec fastlane lint
-  unit-test:
-    runs-on: ubuntu-latest
-    needs: lint
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v3
-      - name: Setup build environment
-        uses: ./.github/actions/setup-build-environment
-      - run: bundle exec fastlane unit_test
   build-irmagobridge-ios:
     runs-on: macos-12
-    needs: lint
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -43,7 +23,6 @@ jobs:
           path: ios/Runner/Irmagobridge.xcframework/
   build-irmagobridge-android:
     runs-on: ubuntu-latest
-    needs: lint
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -57,9 +36,7 @@ jobs:
   build-app-ios-alpha:
     # Ad Hoc builds do not require unique build numbers, so we can build this on every push.
     runs-on: macos-12
-    needs:
-      - unit-test
-      - build-irmagobridge-ios
+    needs: build-irmagobridge-ios
     environment: ad-hoc-alpha
     timeout-minutes: 20 # To prevent job runs to hang indefinitely. See comment in ios_build_app lane in the Fastfile.
     steps:
@@ -96,9 +73,7 @@ jobs:
           path: ./fastlane/build/*.ipa
   build-app-android-alpha:
     runs-on: ubuntu-latest
-    needs:
-      - unit-test
-      - build-irmagobridge-android
+    needs: build-irmagobridge-android
     environment: android-alpha
     # For now, we also build the beta flavor using the alpha secrets to enable ad-hoc distribution of the
     # beta flavor Android app. This is needed, because the irma-frontend-packages use the app identifier of the

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -38,7 +38,6 @@ jobs:
     runs-on: macos-12
     needs: build-irmagobridge-ios
     environment: ad-hoc-alpha
-    timeout-minutes: 20 # To prevent job runs to hang indefinitely. See comment in ios_build_app lane in the Fastfile.
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -168,7 +167,6 @@ jobs:
     needs: version-check
     if: needs.version-check.outputs.version-changed == 'true'
     environment: app-store-beta
-    timeout-minutes: 20 # To prevent job runs to hang indefinitely. See comment in ios_build_app lane in the Fastfile.
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -75,12 +75,9 @@ jobs:
         with:
           name: prototypes-alpha-android
           path: ./build/app/outputs/apk/alpha/release/*.apk
-  build-app-ios:
+  build-app-ios-alpha:
     runs-on: macos-12 # MacOS version is pinned, because it determines which XCode version is used.
     needs: build-irmagobridge-ios
-    strategy:
-      matrix:
-        flavor: [ alpha, beta ]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -104,14 +101,14 @@ jobs:
       - name: Build
         run: >
           bundle exec fastlane ios_build_app
-          flavor:${{ matrix.flavor }}
+          flavor:alpha
           certificate_path:profiles/ios_development.p12
           certificate_password:${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD }}
           provisioning_profile_path:profiles/development.mobileprovision
           code_signing_identity:"iPhone Developer"
       - uses: actions/upload-artifact@v3
         with:
-          name: app-${{ matrix.flavor }}-ios
+          name: app-alpha-ios
           path: ./fastlane/build/*.ipa
   build-app-android:
     runs-on: ubuntu-latest

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -93,8 +93,26 @@ jobs:
         with:
           name: irmagobridge-ios
           path: ios/Runner/Irmagobridge.xcframework/
-      # We don't export here, because we don't have signing keys in this environment.
-      - run: bundle exec fastlane ios_build_app flavor:${{ matrix.flavor }} export:false
+      - name: Decode binary environment secrets
+        env:
+          APPLE_DEVELOPMENT_CERTIFICATE: ${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE }}
+          APPLE_DEVELOPMENT_PROVISIONING_PROFILE: ${{ secrets.APPLE_DEVELOPMENT_PROVISIONING_PROFILE }}
+        run: |
+          mkdir -p ./fastlane/profiles
+          echo $APPLE_DEVELOPMENT_CERTIFICATE | base64 --decode > ./fastlane/profiles/ios_development.p12
+          echo $APPLE_DEVELOPMENT_PROVISIONING_PROFILE | base64 --decode > ./fastlane/profiles/development.mobileprovision
+      - name: Build
+        run: >
+          bundle exec fastlane ios_build_app
+          flavor:${{ matrix.flavor }}
+          certificate_path:profiles/ios_development.p12
+          certificate_password:${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD }}
+          provisioning_profile_path:profiles/development.mobileprovision
+          code_signing_identity:"iPhone Developer"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: app-${{ matrix.flavor }}-ios
+          path: ./fastlane/build/*.ipa
   build-app-android:
     runs-on: ubuntu-latest
     needs: build-irmagobridge-android
@@ -155,7 +173,8 @@ jobs:
           mkdir -p ./fastlane/profiles
           echo $APPLE_DEVELOPMENT_CERTIFICATE | base64 --decode > ./fastlane/profiles/ios_development.p12
           echo $APPLE_DEVELOPMENT_PROVISIONING_PROFILE | base64 --decode > ./fastlane/profiles/development.mobileprovision
-      - run: >
+      - name: Build
+        run: >
           bundle exec fastlane ios_build_integration_test
           certificate_path:profiles/ios_development.p12
           certificate_password:${{ secrets.APPLE_DEVELOPMENT_CERTIFICATE_PASSWORD }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bump irmago version to [0.12.4](https://github.com/privacybydesign/irmago/releases/tag/v0.12.4)
 
+### Internal
+- Use 'flutter build ipa' in Fastlane to build iOS app
+
 ## [7.3.1] - 2023-05-04 (in beta 2023-04-26)
 ### Changed
 - Randomize which success graphic is shown

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -181,7 +181,7 @@ lane :ios_build_app do |options|
 
   Dir.chdir("..") do
     sh("flutter", "build", "ipa", "--release", "--export-options-plist", "./ios/Runner/Flutter-Build-IPA.plist")
-    sh("cp", "./build/ios/ipa/*.ipa", "./fastlane/build/app-#{options[:flavor]}-ios-#{export_method}.ipa")
+    sh("cp ./build/ios/ipa/*.ipa ./fastlane/build/app-#{options[:flavor]}-ios-#{export_method}.ipa")
   end
 end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -180,22 +180,9 @@ lane :ios_build_app do |options|
     code_signing_identity: options[:code_signing_identity]
   )
 
-  # The 'flutter build ipa' command does not support changing the export method in Flutter 2.
-  # Therefore, we use 'flutter build ios' for now with the --no-codesign option
-  # and then we use Fastlane's build_ios_app action to sign and export the build.
-  # This work-around causes the lane to get stuck indefinitely sometimes.
   Dir.chdir("..") do
-    sh("flutter", "build", "ios", "--release", "--no-codesign")
-  end
-
-  if export
-    build_ios_app(
-      scheme: "Runner",
-      workspace: "ios/Runner.xcworkspace",
-      output_directory: "fastlane/build",
-      output_name: "app-#{options[:flavor]}-ios-#{export_method}.ipa",
-      export_method: export_method
-    )
+    sh("flutter", "build", "ipa", "--release", "--export-options-plist", "./ios/Runner/Flutter-Build-IPA.plist")
+    sh("cp", "./build/ios/ipa/*.ipa", "./fastlane/build/app-#{options[:flavor]}-ios-#{export_method}.ipa")
   end
 end
 
@@ -288,6 +275,21 @@ private_lane :set_provisioning_profile do |options|
   # Otherwise, we use the profile that is currently selected in XCode.
   if options[:provisioning_profile_path]
     provisioning_profile_path = File.absolute_path(options[:provisioning_profile_path])
+
+    # Get uuid of provisioning profile
+    uuid_regex = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/
+    uuid = ""
+    File.open(provisioning_profile_path, "r:BINARY") do |file|
+      file.each_line do |line|
+        encoded_line = line.encode("UTF-8", invalid: :replace, undef: :replace)
+        match_data = encoded_line.match(uuid_regex)
+        if match_data
+          uuid = match_data[0]
+          break
+        end
+      end
+    end
+
     install_provisioning_profile(
       path: provisioning_profile_path
     )
@@ -296,6 +298,19 @@ private_lane :set_provisioning_profile do |options|
       profile: provisioning_profile_path,
       target_filter: "^Runner$",
       code_signing_identity: options[:code_signing_identity] || "iPhone Distribution"
+    )
+    # Set uuid in plist file for flutter
+    set_info_plist_value(
+      path: "ios/Runner/Flutter-Build-IPA.plist",
+      key: "provisioningProfiles",
+      subkey: "foundation.privacybydesign.irmamob",
+      value: uuid
+    )
+    set_info_plist_value(
+      path: "ios/Runner/Flutter-Build-IPA.plist",
+      key: "provisioningProfiles",
+      subkey: "foundation.privacybydesign.irmamob.alpha",
+      value: uuid
     )
   end
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -120,7 +120,6 @@ end
 lane :ios_build do |options|
   ios_build_irmagobridge()
   ios_build_app(
-    export: options[:export],
     flavor: options[:flavor],
     sentry_dsn: options[:sentry_dsn],
     certificate_path: options[:certificate_path],

--- a/fastlane/README.md
+++ b/fastlane/README.md
@@ -214,7 +214,7 @@ The APKs are written to the `build` directory (so `fastlane/build` from the repo
 
 Builds an iOS IPA file for the requested flavor.
 
-For all extra parameters, please check the [documentation of `ios_build_app`](#ios_build_app).
+For all extra parameters, please check the [documentation of `ios_build_app`](#iosbuildapp).
 
 ### ios_build_irmagobridge
 
@@ -246,13 +246,6 @@ If the certificate bundle contains a development certificate, then the code sign
 
 ```sh
 [bundle exec] fastlane ios_build_integration_test code_signing_identity:"iPhone Developer" provisioning_profile_path:<VALUE> certificate_path:<VALUE> certificate_password:<VALUE>
-```
-
-Alternatively, you can run this action without an app provisioning profile by disabling the IPA export.
-This can be useful for testing purposes if you don't have access to the keys.
-
-```sh
-[bundle exec] fastlane ios_build_app flavor:<VALUE> export:false
 ```
 
 The `flavor` parameter accepts the values `alpha` or `beta`.

--- a/ios/Runner/Flutter-Build-IPA.plist
+++ b/ios/Runner/Flutter-Build-IPA.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>provisioningProfiles</key>
+    <dict>
+        <key>foundation.privacybydesign.irmamob</key>
+        <string>00000000-0000-0000-0000-000000000000</string>
+        <key>foundation.privacybydesign.irmamob.alpha</key>
+        <string>00000000-0000-0000-0000-000000000000</string>
+    </dict>
+</dict>
+</plist>


### PR DESCRIPTION
This should fix the issue that the delivery workflow gets stuck so often.

I removed the lint and unit test jobs, because they are not needed anymore. They are covered in the status checks workflow in all scenarios already. So this is a optimisation.