### PR TITLE
test: timestamp cannot always be found

### DIFF
--- a/integration_test/activity_test.dart
+++ b/integration_test/activity_test.dart
@@ -82,7 +82,7 @@ void main() {
         // Find the activity timestamp
         final timestampFinder = find.byKey(const Key('activity_timestamp'));
         await tester.scrollUntilVisible(
-          timestampFinder.hitTestable(),
+          timestampFinder,
           150,
           maxScrolls: 20,
           duration: const Duration(milliseconds: 500), // Wait for scrollbar to flex back at the end of the list on iOS.


### PR DESCRIPTION
Removed the hitTestable() on the timestamp finder because its not hitTestable. There are no events on the widget (e.g tap) . It's very noticeable on iPhone 11.