### PR TITLE
fix: LoadingScreen StreamBuilder triggers multiple navigation actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 ### Fixed
-- LoadingScreen StreamBuilder creates multiple streams sometimes
+- LoadingScreen StreamBuilder triggers multiple navigation actions
 ## [7.4.1] - 2023-06-15
 ### Added
 - Show custom error message when the server returns a response indicating that the user is not registered

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- LoadingScreen StreamBuilder creates multiple streams sometimes
 ## [7.4.1] - 2023-06-15
 ### Added
 - Show custom error message when the server returns a response indicating that the user is not registered

--- a/lib/src/screens/loading/loading_screen.dart
+++ b/lib/src/screens/loading/loading_screen.dart
@@ -19,14 +19,12 @@ class LoadingScreen extends StatefulWidget {
 
 class _LoadingScreenState extends State<LoadingScreen> {
   StreamSubscription<EnrollmentStatus>? _enrollmentStatusSubscription;
-  Stream<ErrorEvent>? _errorEventStream;
 
   @override
   void initState() {
     super.initState();
     WidgetsBinding.instance.addPostFrameCallback((_) {
       final repo = IrmaRepositoryProvider.of(context);
-      _errorEventStream = repo.getFatalErrors();
       _enrollmentStatusSubscription = repo.getEnrollmentStatus().listen(_enrollmentStatusHandler);
     });
   }
@@ -52,7 +50,7 @@ class _LoadingScreenState extends State<LoadingScreen> {
 
   @override
   Widget build(BuildContext context) => StreamBuilder<ErrorEvent>(
-        stream: _errorEventStream,
+        stream: IrmaRepositoryProvider.of(context).getFatalErrors(),
         builder: (context, snapshot) {
           if (snapshot.hasData) {
             final error = snapshot.data;

--- a/lib/src/screens/loading/loading_screen.dart
+++ b/lib/src/screens/loading/loading_screen.dart
@@ -26,18 +26,24 @@ class _LoadingScreenState extends State<LoadingScreen> {
     super.initState();
 
     final repo = IrmaRepositoryProvider.of(context);
-    _enrollmentStatusSubscription = repo.getEnrollmentStatus().listen((EnrollmentStatus status) {
-      if (status == EnrollmentStatus.enrolled) {
+    _enrollmentStatusSubscription = repo.getEnrollmentStatus().listen(_enrollmentStatusHandler);
+  }
+
+  void _enrollmentStatusHandler(EnrollmentStatus status) {
+    if (status == EnrollmentStatus.enrolled) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         Navigator.of(context).pushReplacementNamed(HomeScreen.routeName);
-      } else if (status == EnrollmentStatus.unenrolled) {
-        // Because this happens on start-up immediately, we have to make sure a smooth transition is being made.
+      });
+    } else if (status == EnrollmentStatus.unenrolled) {
+      // Because this happens on start-up immediately, we have to make sure a smooth transition is being made.
+      WidgetsBinding.instance.addPostFrameCallback((_) {
         Navigator.of(context).pushReplacement(PageRouteBuilder(
           pageBuilder: (context, a1, a2) => EnrollmentScreen(),
           transitionsBuilder: (context, a1, a2, child) => FadeTransition(opacity: a1, child: child),
           transitionDuration: const Duration(milliseconds: 500),
         ));
-      }
-    });
+      });
+    }
   }
 
   @override

--- a/lib/src/screens/loading/loading_screen.dart
+++ b/lib/src/screens/loading/loading_screen.dart
@@ -24,26 +24,23 @@ class _LoadingScreenState extends State<LoadingScreen> {
   @override
   void initState() {
     super.initState();
-
-    final repo = IrmaRepositoryProvider.of(context);
-    _errorEventStream = repo.getFatalErrors();
-    _enrollmentStatusSubscription = repo.getEnrollmentStatus().listen(_enrollmentStatusHandler);
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final repo = IrmaRepositoryProvider.of(context);
+      _errorEventStream = repo.getFatalErrors();
+      _enrollmentStatusSubscription = repo.getEnrollmentStatus().listen(_enrollmentStatusHandler);
+    });
   }
 
   void _enrollmentStatusHandler(EnrollmentStatus status) {
     if (status == EnrollmentStatus.enrolled) {
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context).pushReplacementNamed(HomeScreen.routeName);
-      });
+      Navigator.of(context).pushReplacementNamed(HomeScreen.routeName);
     } else if (status == EnrollmentStatus.unenrolled) {
       // Because this happens on start-up immediately, we have to make sure a smooth transition is being made.
-      WidgetsBinding.instance.addPostFrameCallback((_) {
-        Navigator.of(context).pushReplacement(PageRouteBuilder(
-          pageBuilder: (context, a1, a2) => EnrollmentScreen(),
-          transitionsBuilder: (context, a1, a2, child) => FadeTransition(opacity: a1, child: child),
-          transitionDuration: const Duration(milliseconds: 500),
-        ));
-      });
+      Navigator.of(context).pushReplacement(PageRouteBuilder(
+        pageBuilder: (context, a1, a2) => EnrollmentScreen(),
+        transitionsBuilder: (context, a1, a2, child) => FadeTransition(opacity: a1, child: child),
+        transitionDuration: const Duration(milliseconds: 500),
+      ));
     }
   }
 

--- a/lib/src/screens/loading/loading_screen.dart
+++ b/lib/src/screens/loading/loading_screen.dart
@@ -18,14 +18,15 @@ class LoadingScreen extends StatefulWidget {
 }
 
 class _LoadingScreenState extends State<LoadingScreen> {
-  EnrollmentStatus? status;
   StreamSubscription<EnrollmentStatus>? _enrollmentStatusSubscription;
+  Stream<ErrorEvent>? _errorEventStream;
 
   @override
   void initState() {
     super.initState();
 
     final repo = IrmaRepositoryProvider.of(context);
+    _errorEventStream = repo.getFatalErrors();
     _enrollmentStatusSubscription = repo.getEnrollmentStatus().listen(_enrollmentStatusHandler);
   }
 
@@ -54,16 +55,17 @@ class _LoadingScreenState extends State<LoadingScreen> {
 
   @override
   Widget build(BuildContext context) => StreamBuilder<ErrorEvent>(
-      stream: IrmaRepositoryProvider.of(context).getFatalErrors(),
-      builder: (context, snapshot) {
-        if (snapshot.hasData) {
-          final error = snapshot.data;
-          return ErrorScreen.fromEvent(
-            error: error!,
+        stream: _errorEventStream,
+        builder: (context, snapshot) {
+          if (snapshot.hasData) {
+            final error = snapshot.data;
+            return ErrorScreen.fromEvent(
+              error: error!,
+            );
+          }
+          return const SplashScreen(
+            isLoading: true,
           );
-        }
-        return const SplashScreen(
-          isLoading: true,
-        );
-      });
+        },
+      );
 }


### PR DESCRIPTION
Occasionally, when starting the app with a URL, the `StreamBuilder` in the LoadingScreen builds multiple times which leads to more than one navigation action, leading to more than one home screen and disruptions in the session flow.