### PR TITLE
fix: notifications keep loading

### DIFF
--- a/lib/src/screens/notifications/handlers/credential_status_notifications_handler.dart
+++ b/lib/src/screens/notifications/handlers/credential_status_notifications_handler.dart
@@ -18,12 +18,14 @@ class CredentialStatusNotificationsHandler extends NotificationHandler {
       // Check if a notification should be shown for this credential, and if so which type
       CredentialStatusNotificationType? notificationType;
 
-      if (cred.revoked) {
-        notificationType = CredentialStatusNotificationType.revoked;
-      } else if (cred.expired) {
-        notificationType = CredentialStatusNotificationType.expired;
-      } else if (CardExpiryDate(cred.expires).expiresSoon) {
-        notificationType = CredentialStatusNotificationType.expiringSoon;
+      if (!cred.isKeyshareCredential) {
+        if (cred.revoked) {
+          notificationType = CredentialStatusNotificationType.revoked;
+        } else if (cred.expired) {
+          notificationType = CredentialStatusNotificationType.expired;
+        } else if (CardExpiryDate(cred.expires).expiresSoon) {
+          notificationType = CredentialStatusNotificationType.expiringSoon;
+        }
       }
 
       // If a notification should be shown for this credential

--- a/lib/src/screens/notifications/handlers/credential_status_notifications_handler.dart
+++ b/lib/src/screens/notifications/handlers/credential_status_notifications_handler.dart
@@ -11,7 +11,10 @@ class CredentialStatusNotificationsHandler extends NotificationHandler {
   Future<List<Notification>> loadNotifications(IrmaRepository repo, List<Notification> notifications) async {
     final List<Notification> updatedNotifications = notifications;
 
-    for (final cred in repo.credentials.values) {
+    // Wait until the credentials are present
+    final credentials = await repo.getCredentials().first;
+
+    for (final cred in credentials.values) {
       // Check if a notification should be shown for this credential, and if so which type
       CredentialStatusNotificationType? notificationType;
 


### PR DESCRIPTION
Wait until credentials are present instead of using `repo.credentials`