### PR TITLE
chore: added open.yivi.app to associated domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Internal
+- Added open.yivi.app to associated domains
+
 ## [7.5.0] - 2023-09-13
 ### Added
 - Credential status notifications

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,12 @@
               <category android:name="android.intent.category.BROWSABLE" />
               <data android:scheme="https" android:host="irma.app" android:pathPrefix="/-/" />
             </intent-filter>
+              <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="https" android:host="open.yivi.app" android:pathPrefix="/-/" />
+            </intent-filter>
             <intent-filter>
               <action android:name="android.intent.action.VIEW" />
               <category android:name="android.intent.category.DEFAULT" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -39,10 +39,10 @@
               <data android:scheme="https" android:host="irma.app" android:pathPrefix="/-/" />
             </intent-filter>
             <intent-filter android:autoVerify="true">
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="https" android:host="open.yivi.app" android:pathPrefix="/-/" />
+              <action android:name="android.intent.action.VIEW" />
+              <category android:name="android.intent.category.DEFAULT" />
+              <category android:name="android.intent.category.BROWSABLE" />
+              <data android:scheme="https" android:host="open.yivi.app" android:pathPrefix="/-/" />
             </intent-filter>
             <intent-filter>
               <action android:name="android.intent.action.VIEW" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,7 +38,7 @@
               <category android:name="android.intent.category.BROWSABLE" />
               <data android:scheme="https" android:host="irma.app" android:pathPrefix="/-/" />
             </intent-filter>
-              <intent-filter android:autoVerify="true">
+            <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />

--- a/ios/Runner/Runner.entitlements
+++ b/ios/Runner/Runner.entitlements
@@ -5,6 +5,7 @@
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:irma.app</string>
+		<string>applinks:open.yivi.app</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Verified this by running: 
Android: `adb shell am start -d https://open.yivi.app/-/ `
Ios: `xcrun simctl openurl booted 'https://open.yivi.app/-/'`
