### PR TITLE
Chore: follow `isULIssueUrl` setting from credential type configurati…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 ### Changed
 - Update irmago to version 0.14.0
+- Follow `isULIssueUrl` setting from credential type configuration when opening the issuer website
 
 ### Fixed
 - Demo test schemes with keyshare server cannot be activated

--- a/lib/src/data/irma_repository.dart
+++ b/lib/src/data/irma_repository.dart
@@ -554,6 +554,11 @@ class IrmaRepository {
       ));
     }
 
+    // If the issue URL is a universal link, then we ask the OS to open the appropriate application.
+    if (cred.isULIssueUrl) {
+      return openURLExternally(url, suppressQrScanner: true);
+    }
+
     return openURL(url);
   }
 


### PR DESCRIPTION
…on when opening the issuer website