### PR TITLE
Fix for gomobile xcodebuild failing because of symlink

### DIFF
--- a/bind_go.sh
+++ b/bind_go.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
 
+# Fix xcodebuild (15.0.1) symlink tmpdir issue (https://developer.apple.com/forums/thread/738091)
+TMPDIR=$(cd -P "$TMPDIR" && pwd)
+
 gomobile bind -target android -androidapi 23 -o android/irmagobridge/irmagobridge.aar github.com/privacybydesign/irmamobile/irmagobridge
 gomobile bind -target ios -iosversion 12.0 -o ios/Runner/Irmagobridge.xcframework github.com/privacybydesign/irmamobile/irmagobridge


### PR DESCRIPTION
The error happens (and might be isolated) at a Mac with a Apple M1 Pro chip. When running `./bind_go.sh` gomobile fails for the iOS build with the following error:

```
gomobile: xcodebuild -create-xcframework -framework /var/folders/wl/223633ds29gghp1zbmnp317m0000gp/T/gomobile-work-756136562/ios/iphoneos/Irmagobridge.framework -framework /var/folders/wl/223633ds29gghp1zbmnp317m0000gp/T/gomobile-work-756136562/iossimulator/iphonesimulator/Irmagobridge.framework -framework /var/folders/wl/223633ds29gghp1zbmnp317m0000gp/T/gomobile-work-756136562/iossimulator/iphonesimulator/Irmagobridge.framework -output ios/Runner/Irmagobridge.xcframework failed: exit status 70
error: cannot compute path of binary 'Path(str: "/private/var/folders/wl/223633ds29gghp1zbmnp317m0000gp/T/gomobile-work-756136562/ios/iphoneos/Irmagobridge.framework/Versions/A/Irmagobridge")' relative to that of '/var/folders/wl/223633ds29gghp1zbmnp317m0000gp/T/gomobile-work-756136562/ios/iphoneos/Irmagobridge.framework'
```

The error is fixed by transforming the symlink into it's real location before running xcodebuild. Source: https://developer.apple.com/forums/thread/738091

I suggest further testing/investigating to rule out a configuration issue on my local setup.