### PR TITLE
CI/CD: fix failing xcode-select after policy change in GitHub Actions MacOS runner image

### DIFF
--- a/.github/actions/setup-build-environment/action.yml
+++ b/.github/actions/setup-build-environment/action.yml
@@ -3,11 +3,6 @@ description: This action installs all build tools needed for irmamobile and cach
 runs:
   using: composite
   steps:
-    # The macOS runner's default XCode version changes over time, so we need to pin it to a specific version.
-    - name: Select Xcode version
-      if: runner.os == 'macOS'
-      run: ./ci_scripts/select_xcode.sh
-      shell: bash
     - uses: actions/setup-java@v4
       with:
         distribution: temurin

--- a/.github/workflows/delivery.yml
+++ b/.github/workflows/delivery.yml
@@ -10,7 +10,7 @@ concurrency: ${{ github.ref }}
 
 jobs:
   build-irmagobridge-ios:
-    runs-on: macos-14
+    runs-on: macos-15 # MacOS version is pinned, because it determines which XCode version is used.
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
           path: android/irmagobridge/irmagobridge.aar
   build-app-ios-alpha:
     # Ad Hoc builds do not require unique build numbers, so we can build this on every push.
-    runs-on: macos-14
+    runs-on: macos-15 # MacOS version is pinned, because it determines which XCode version is used.
     needs: build-irmagobridge-ios
     environment: ad-hoc-alpha
     steps:
@@ -164,7 +164,7 @@ jobs:
         shell: bash
         continue-on-error: true
   build-app-ios-beta:
-    runs-on: macos-14
+    runs-on: macos-15 # MacOS version is pinned, because it determines which XCode version is used.
     needs: version-check
     if: needs.version-check.outputs.version-changed == 'true'
     environment: app-store-beta

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -220,6 +220,7 @@ jobs:
     strategy:
       matrix:
         file_name: ${{ fromJson(needs.build-integration-test-ios.outputs.matrix) }}
+      fail-fast: false # To prevent we have to re-run all tests when one run is flaky.
     concurrency: integration-test-ios-${{ matrix.file_name }} # To prevent that we use too much test resources at the same time.
     steps:
       - name: Download test artifacts

--- a/.github/workflows/status-checks.yml
+++ b/.github/workflows/status-checks.yml
@@ -34,7 +34,7 @@ jobs:
         uses: ./.github/actions/setup-build-environment
       - run: bundle exec fastlane unit_test
   build-irmagobridge-ios:
-    runs-on: macos-14 # MacOS version is pinned, because it determines which XCode version is used.
+    runs-on: macos-15 # MacOS version is pinned, because it determines which XCode version is used.
     needs: lint
     steps:
       - name: Check out repository
@@ -80,7 +80,7 @@ jobs:
           name: prototypes-alpha-android
           path: ./build/app/outputs/apk/alpha/release/*.apk
   build-app-ios-alpha:
-    runs-on: macos-14 # MacOS version is pinned, because it determines which XCode version is used.
+    runs-on: macos-15 # MacOS version is pinned, because it determines which XCode version is used.
     needs: build-irmagobridge-ios
     steps:
       - name: Check out repository
@@ -152,7 +152,7 @@ jobs:
           name: app-${{ matrix.flavor }}-android-${{ matrix.type }}
           path: ./fastlane/build/*
   build-integration-test-ios:
-    runs-on: macos-14 # MacOS version is pinned, because it determines which XCode version is used.
+    runs-on: macos-15 # MacOS version is pinned, because it determines which XCode version is used.
     needs: build-irmagobridge-ios
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}

--- a/ci_scripts/select_xcode.sh
+++ b/ci_scripts/select_xcode.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euxo pipefail
-
-XCODE_VERSION="16.0"
-
-# Location is based on the Xcode versions bundled with the macOS runners in GitHub Actions.
-# https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#xcode
-sudo xcode-select -s /Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer


### PR DESCRIPTION
The new XCode patch policy in the GitHub actions runner images don't require explicit pinning of the XCode version anymore. They now guarantee that only one XCode major is used per MacOS version.

https://github.com/actions/runner-images/issues/10703

Currently, we are using XCode 16 on MacOS 14. That's not allowed anymore in the new policy. To use XCode 16 we simple have to use the MacOS 15 runner image.