### PR TITLE
Add option to view and accept new terms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add changed terms & conditions dialog that shows up when the terms have changed
 
 ## [7.8.1] - 2025-05-07
 ### Changed

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -21,8 +21,8 @@
   "new_terms_and_conditions": {
     "title": "New terms and conditions",
     "explanation_markdown": "The management of Yivi has recently been transferred to another organization ([Yivi B.V.](https://yivi.app/en/about_yivi)).\n\nTherefore, the terms and conditions have changed slightly.\n\nWe ask you to [read them]({terms_url}) and agree to them below.",
-    "accept": "I accept",
-    "dismiss": "Ask me later"
+    "accept": "Accept",
+    "dismiss": "Not now"
   },
   "action_feedback": {
     "ok": "OK"

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -20,16 +20,10 @@
   },
   "new_terms_and_conditions": {
     "title": "New terms & conditions",
-    "explanation_markdown": "The terms and conditions have changed. Please accept the new terms to keep using Yivi.",
+    "explanation": "The terms and conditions have changed. Please accept the new terms in order to keep using Yivi.",
     "read_terms": "View the new terms",
     "accept": "I accept",
-    "reject": "Stop using Yivi",
-    "reject_dialog": {
-      "title": "Are you sure?",
-      "body": "If you proceed all your data will be deleted. This is permanent. If you wish to start using Yivi again you will have to obtain your data again.",
-      "cancel": "Cancel",
-      "delete": "Delete data"
-    }
+    "dismiss": "Ask me later"
   },
   "action_feedback": {
     "ok": "OK"

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -18,6 +18,19 @@
     "collapse_hint": "Double tap to collapse",
     "refresh": "Refresh"
   },
+  "new_terms_and_conditions": {
+    "title": "New terms & conditions",
+    "explanation_markdown": "The terms and conditions have changed. Please accept the new terms to keep using Yivi.",
+    "read_terms": "View the new terms",
+    "accept": "I accept",
+    "reject": "Stop using Yivi",
+    "reject_dialog": {
+      "title": "Are you sure?",
+      "body": "If you proceed all your data will be deleted. This is permanent. If you wish to start using Yivi again you will have to obtain your data again.",
+      "cancel": "Cancel",
+      "delete": "Delete data"
+    }
+  },
   "action_feedback": {
     "ok": "OK"
   },
@@ -284,7 +297,7 @@
       "point_1": "You decide what data you store, and what you share.",
       "point_2": "Your data only resides on your phone, safe and secure. Nowhere else.",
       "point_3": "Nobody can see your data or your transactions, not even Yivi!",
-      "accept_markdown": "Yes, I accept the [terms and conditions](https://www.yivi.app/en/terms-and-conditions)"
+      "accept_markdown": "Yes, I accept the [terms and conditions]({terms_url})"
     },
     "error_reporting": {
       "accept": {

--- a/assets/locales/en.json
+++ b/assets/locales/en.json
@@ -19,9 +19,8 @@
     "refresh": "Refresh"
   },
   "new_terms_and_conditions": {
-    "title": "New terms & conditions",
-    "explanation": "The terms and conditions have changed. Please accept the new terms in order to keep using Yivi.",
-    "read_terms": "View the new terms",
+    "title": "New terms and conditions",
+    "explanation_markdown": "The management of Yivi has recently been transferred to another organization ([Yivi B.V.](https://yivi.app/en/about_yivi)).\n\nTherefore, the terms and conditions have changed slightly.\n\nWe ask you to [read them]({terms_url}) and agree to them below.",
     "accept": "I accept",
     "dismiss": "Ask me later"
   },

--- a/assets/locales/nl.json
+++ b/assets/locales/nl.json
@@ -20,16 +20,10 @@
   },
   "new_terms_and_conditions": {
     "title": "Nieuwe voorwaarden",
-    "explanation": "De voorwaarden zijn veranderd. Ga akkoord met de nieuwe voorwaarden om Yivi te blijven gebruiken.",
+    "explanation": "De voorwaarden zijn gewijzigd. Ga akkoord met de nieuwe voorwaarden om Yivi te blijven gebruiken.",
     "read_terms": "Bekijk de nieuwe voorwaarden",
     "accept": "Accepteer",
-    "reject": "Stop Yivi te gebruiken",
-    "reject_dialog": {
-      "title": "Weet je het zeker?",
-      "body": "Als je doorgaat worden al je gegevens verwijderd. Dit is permanent. Als je Yivi opnieuw wilt gebruiken zul je al je gegevens opnieuw op moeten halen.",
-      "cancel": "Annuleren",
-      "delete": "Gegevens verwijderen"
-    }
+    "dismiss": "Niet nu"
   },
   "action_feedback": {
     "ok": "OK"

--- a/assets/locales/nl.json
+++ b/assets/locales/nl.json
@@ -20,8 +20,7 @@
   },
   "new_terms_and_conditions": {
     "title": "Nieuwe voorwaarden",
-    "explanation": "De voorwaarden zijn gewijzigd. Ga akkoord met de nieuwe voorwaarden om Yivi te blijven gebruiken.",
-    "read_terms": "Bekijk de nieuwe voorwaarden",
+    "explanation_markdown": "Het beheer van Yivi ligt sinds kort bij een andere organisatie ([Yivi B.V.](https://yivi.app/about_yivi)).\n\nDaarom zijn de voorwaarden iets veranderd.\n\nWe vragen je ze te [lezen]({terms_url}) en hieronder akkoord te gaan.",
     "accept": "Accepteer",
     "dismiss": "Niet nu"
   },

--- a/assets/locales/nl.json
+++ b/assets/locales/nl.json
@@ -18,6 +18,19 @@
     "collapse_hint": "Klik dubbel om dicht te vouwen",
     "refresh": "Verversen"
   },
+  "new_terms_and_conditions": {
+    "title": "Nieuwe voorwaarden",
+    "explanation": "De voorwaarden zijn veranderd. Ga akkoord met de nieuwe voorwaarden om Yivi te blijven gebruiken.",
+    "read_terms": "Bekijk de nieuwe voorwaarden",
+    "accept": "Accepteer",
+    "reject": "Stop Yivi te gebruiken",
+    "reject_dialog": {
+      "title": "Weet je het zeker?",
+      "body": "Als je doorgaat worden al je gegevens verwijderd. Dit is permanent. Als je Yivi opnieuw wilt gebruiken zul je al je gegevens opnieuw op moeten halen.",
+      "cancel": "Annuleren",
+      "delete": "Gegevens verwijderen"
+    }
+  },
   "action_feedback": {
     "ok": "OK"
   },
@@ -284,7 +297,7 @@
       "point_1": "Jij bepaalt wat je opslaat, wat je deelt en met wie.",
       "point_2": "Jouw gegevens staan alleen op je mobiel, wel zo veilig.",
       "point_3": "Niemand kijkt mee, ook Yivi niet!",
-      "accept_markdown": "Ja, ik ga akkoord met de [algemene voorwaarden](https://www.yivi.app/algemene-voorwaarden)"
+      "accept_markdown": "Ja, ik ga akkoord met de [algemene voorwaarden]({terms_url})"
     },
     "error_reporting": {
       "accept": {

--- a/assets/locales/nl.json
+++ b/assets/locales/nl.json
@@ -21,7 +21,7 @@
   "new_terms_and_conditions": {
     "title": "Nieuwe voorwaarden",
     "explanation_markdown": "Het beheer van Yivi ligt sinds kort bij een andere organisatie ([Yivi B.V.](https://yivi.app/about_yivi)).\n\nDaarom zijn de voorwaarden iets veranderd.\n\nWe vragen je ze te [lezen]({terms_url}) en hieronder akkoord te gaan.",
-    "accept": "Accepteer",
+    "accept": "Akkoord",
     "dismiss": "Niet nu"
   },
   "action_feedback": {

--- a/integration_test/helpers/helpers.dart
+++ b/integration_test/helpers/helpers.dart
@@ -12,6 +12,7 @@ import 'package:irmamobile/main.dart';
 import 'package:irmamobile/src/data/irma_repository.dart';
 import 'package:irmamobile/src/models/session.dart';
 import 'package:irmamobile/src/providers/irma_repository_provider.dart';
+import 'package:irmamobile/src/providers/preferences_provider.dart';
 import 'package:irmamobile/src/screens/data/data_tab.dart';
 import 'package:irmamobile/src/screens/notifications/widgets/notification_card.dart';
 import 'package:irmamobile/src/screens/session/widgets/issuance_permission.dart';
@@ -51,6 +52,7 @@ Future<void> pumpIrmaApp(WidgetTester tester, IrmaRepository repo, [Locale? defa
     ProviderScope(
       overrides: [
         irmaRepositoryProvider.overrideWithValue(repo),
+        preferencesProvider.overrideWithValue(repo.preferences),
       ],
       child: IrmaApp(
         defaultLanguage: defaultLanguage ?? const Locale('en', 'EN'),

--- a/integration_test/irma_binding.dart
+++ b/integration_test/irma_binding.dart
@@ -45,9 +45,15 @@ Nu1bRk5gLEwmR5+V6MSFQWyWBkwacOt8
     return _instance!;
   }
 
-  Future<void> setUp({EnrollmentStatus enrollmentStatus = EnrollmentStatus.enrolled}) async {
+  Future<void> setUp(
+      {EnrollmentStatus enrollmentStatus = EnrollmentStatus.enrolled, bool acceptedTermsAndConditions = true}) async {
     assert(enrollmentStatus != EnrollmentStatus.undetermined);
-    _preferences ??= await IrmaPreferences.fromInstance();
+    _preferences ??= await IrmaPreferences.fromInstance(
+      mostRecentTermsUrlNl: 'testurl',
+      mostRecentTermsUrlEn: 'testurl',
+    );
+
+    _preferences!.markLatestTermsAsAccepted(acceptedTermsAndConditions);
 
     _bridge.dispatch(AppReadyEvent());
     EnrollmentStatusEvent currEnrollmentStatus = await _expectBridgeEventGuarded<EnrollmentStatusEvent>(

--- a/integration_test/new_terms_test.dart
+++ b/integration_test/new_terms_test.dart
@@ -27,7 +27,6 @@ void main() {
       expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
       await unlockAndWaitForHome(tester);
 
-      // after logging out the terms changed dialog should not show anymore
       await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
 
       final logOutButton = find.byKey(const Key('log_out_button'));
@@ -35,6 +34,7 @@ void main() {
       await tester.scrollUntilVisible(logOutButton, 100);
       await tester.tapAndSettle(logOutButton);
 
+      // after logging out the terms changed dialog should show again
       expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
     });
 

--- a/integration_test/new_terms_test.dart
+++ b/integration_test/new_terms_test.dart
@@ -11,44 +11,46 @@ void main() {
   final irmaBinding = IntegrationTestIrmaBinding.ensureInitialized();
   WidgetController.hitTestWarningShouldBeFatal = true;
 
-  setUp(() async => irmaBinding.setUp(acceptedTermsAndConditions: false));
-  tearDown(() => irmaBinding.tearDown());
+  group('terms-dialog', () {
+    setUp(() => irmaBinding.setUp(acceptedTermsAndConditions: false));
+    tearDown(() => irmaBinding.tearDown());
 
-  testWidgets('new terms dialog accept', (tester) async {
-    await pumpIrmaApp(tester, irmaBinding.repository);
+    testWidgets('new terms dialog dismiss', (tester) async {
+      await pumpIrmaApp(tester, irmaBinding.repository);
 
-    // the first time with new terms the dialog should show
-    expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
+      // the first time with new terms the dialog should show
+      expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
 
-    final acceptButton = find.byKey(const Key('bottom_bar_primary'));
-    await tester.tapAndSettle(acceptButton);
+      final acceptButton = find.byKey(const Key('bottom_bar_secondary'));
+      await tester.tapAndSettle(acceptButton);
 
-    expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
-    await unlockAndWaitForHome(tester);
+      expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
+      await unlockAndWaitForHome(tester);
 
-    // after logging out the terms changed dialog should not show anymore
-    await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
-    await tester.tapAndSettle(find.byKey(const Key('log_out_button')));
+      // after logging out the terms changed dialog should not show anymore
+      await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
+      await tester.tapAndSettle(find.byKey(const Key('log_out_button')));
 
-    expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
-  });
+      expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
+    });
 
-  testWidgets('new terms dialog dismiss', (tester) async {
-    await pumpIrmaApp(tester, irmaBinding.repository);
+    testWidgets('new terms dialog accept', (tester) async {
+      await pumpIrmaApp(tester, irmaBinding.repository);
 
-    // the first time with new terms the dialog should show
-    expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
+      // the first time with new terms the dialog should show
+      expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
 
-    final acceptButton = find.byKey(const Key('bottom_bar_secondary'));
-    await tester.tapAndSettle(acceptButton);
+      final acceptButton = find.byKey(const Key('bottom_bar_primary'));
+      await tester.tapAndSettle(acceptButton);
 
-    expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
-    await unlockAndWaitForHome(tester);
+      expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
+      await unlockAndWaitForHome(tester);
 
-    // after logging out the terms changed dialog should not show anymore
-    await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
-    await tester.tapAndSettle(find.byKey(const Key('log_out_button')));
+      // after logging out the terms changed dialog should not show anymore
+      await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
+      await tester.tapAndSettle(find.byKey(const Key('log_out_button')));
 
-    expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
+      expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
+    });
   });
 }

--- a/integration_test/new_terms_test.dart
+++ b/integration_test/new_terms_test.dart
@@ -14,9 +14,10 @@ void main() {
   setUp(() async => irmaBinding.setUp(acceptedTermsAndConditions: false));
   tearDown(() => irmaBinding.tearDown());
 
-  testWidgets('new terms dialog', (tester) async {
+  testWidgets('new terms dialog accept', (tester) async {
     await pumpIrmaApp(tester, irmaBinding.repository);
 
+    // the first time with new terms the dialog should show
     expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
 
     final acceptButton = find.byKey(const Key('bottom_bar_primary'));
@@ -24,5 +25,30 @@ void main() {
 
     expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
     await unlockAndWaitForHome(tester);
+
+    // after logging out the terms changed dialog should not show anymore
+    await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
+    await tester.tapAndSettle(find.byKey(const Key('log_out_button')));
+
+    expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
+  });
+
+  testWidgets('new terms dialog dismiss', (tester) async {
+    await pumpIrmaApp(tester, irmaBinding.repository);
+
+    // the first time with new terms the dialog should show
+    expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
+
+    final acceptButton = find.byKey(const Key('bottom_bar_secondary'));
+    await tester.tapAndSettle(acceptButton);
+
+    expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
+    await unlockAndWaitForHome(tester);
+
+    // after logging out the terms changed dialog should not show anymore
+    await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
+    await tester.tapAndSettle(find.byKey(const Key('log_out_button')));
+
+    expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
   });
 }

--- a/integration_test/new_terms_test.dart
+++ b/integration_test/new_terms_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+
+import 'helpers/helpers.dart';
+import 'irma_binding.dart';
+import 'util.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final irmaBinding = IntegrationTestIrmaBinding.ensureInitialized();
+  WidgetController.hitTestWarningShouldBeFatal = true;
+
+  setUp(() async => irmaBinding.setUp(acceptedTermsAndConditions: false));
+  tearDown(() => irmaBinding.tearDown());
+
+  testWidgets('new terms dialog', (tester) async {
+    await pumpIrmaApp(tester, irmaBinding.repository);
+
+    expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
+
+    final acceptButton = find.byKey(const Key('bottom_bar_primary'));
+    await tester.tapAndSettle(acceptButton);
+
+    expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
+    await unlockAndWaitForHome(tester);
+  });
+}

--- a/integration_test/new_terms_test.dart
+++ b/integration_test/new_terms_test.dart
@@ -29,7 +29,11 @@ void main() {
 
       // after logging out the terms changed dialog should not show anymore
       await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
-      await tester.tapAndSettle(find.byKey(const Key('log_out_button')));
+
+      final logOutButton = find.byKey(const Key('log_out_button'));
+
+      await tester.scrollUntilVisible(logOutButton, 100);
+      await tester.tapAndSettle(logOutButton);
 
       expect(find.byKey(const Key('terms_changed_dialog')), findsOneWidget);
     });
@@ -48,7 +52,11 @@ void main() {
 
       // after logging out the terms changed dialog should not show anymore
       await tester.tapAndSettle(find.byKey(const Key('nav_button_more')));
-      await tester.tapAndSettle(find.byKey(const Key('log_out_button')));
+
+      final logOutButton = find.byKey(const Key('log_out_button'));
+
+      await tester.scrollUntilVisible(logOutButton, 100);
+      await tester.tapAndSettle(logOutButton);
 
       expect(find.byKey(const Key('terms_changed_dialog')), findsNothing);
     });

--- a/integration_test/test_all.dart
+++ b/integration_test/test_all.dart
@@ -6,12 +6,14 @@ import 'issuance_test.dart' as issuance_test;
 import 'issue_wizard_test.dart' as issue_wizard_test;
 import 'login_test.dart' as login_test;
 import 'more_tab_test.dart' as more_tab_test;
+import 'new_terms_test.dart' as new_terms;
 import 'notifications_test.dart' as notifications_test;
 import 'qr_on_pin_screen_test.dart' as qr_on_pin_screen_test;
 import 'settings_test.dart' as settings_test;
 
 /// Wrapper to execute all tests at once.
 void main() {
+  new_terms.main();
   search_test.main();
   qr_on_pin_screen_test.main();
   enroll_test.main();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ Future<void> main() async {
     WidgetsFlutterBinding.ensureInitialized();
     final preferences = await IrmaPreferences.fromInstance(
         // when the terms have changed, these values should be updated in order to trigger a dialog in the app
-        mostRecentTermsUrlNl: 'https://yivi.app/terms_and_conditions_v3/',
+        mostRecentTermsUrlNl: 'https://yivi.app/terms_and_conditions_v4/',
         mostRecentTermsUrlEn: 'https://yivi.app/en/terms_and_conditions_v3/');
 
     await initSentry(preferences: preferences);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ Future<void> main() async {
     WidgetsFlutterBinding.ensureInitialized();
     final preferences = await IrmaPreferences.fromInstance(
         // when the terms have changed, these values should be updated in order to trigger a dialog in the app
-        mostRecentTermsUrlNl: 'https://yivi.app/terms_and_conditions_v4/',
+        mostRecentTermsUrlNl: 'https://yivi.app/terms_and_conditions_v3/',
         mostRecentTermsUrlEn: 'https://yivi.app/en/terms_and_conditions_v3/');
 
     await initSentry(preferences: preferences);

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,11 @@ Future<void> main() async {
 
   runZonedGuarded<Future<void>>(() async {
     WidgetsFlutterBinding.ensureInitialized();
-    final preferences = await IrmaPreferences.fromInstance();
+    final preferences = await IrmaPreferences.fromInstance(
+        // when the terms have changed, these values should be updated in order to trigger a dialog in the app
+        mostRecentTermsUrlNl: 'https://yivi.app/terms_and_conditions_v3/',
+        mostRecentTermsUrlEn: 'https://yivi.app/en/terms_and_conditions_v3/');
+
     await initSentry(preferences: preferences);
     SecurityContextBinding.ensureInitialized();
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,9 +23,10 @@ Future<void> main() async {
   runZonedGuarded<Future<void>>(() async {
     WidgetsFlutterBinding.ensureInitialized();
     final preferences = await IrmaPreferences.fromInstance(
-        // when the terms have changed, these values should be updated in order to trigger a dialog in the app
-        mostRecentTermsUrlNl: 'https://yivi.app/terms_and_conditions_v3/',
-        mostRecentTermsUrlEn: 'https://yivi.app/en/terms_and_conditions_v3/');
+      // when the terms have changed, these values should be updated in order to trigger a dialog in the app
+      mostRecentTermsUrlNl: 'https://yivi.app/terms_and_conditions_v3/',
+      mostRecentTermsUrlEn: 'https://yivi.app/en/terms_and_conditions_v3/',
+    );
 
     await initSentry(preferences: preferences);
     SecurityContextBinding.ensureInitialized();

--- a/lib/main_prototypes.dart
+++ b/lib/main_prototypes.dart
@@ -11,9 +11,16 @@ import 'src/theme/theme.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  final preferences = await IrmaPreferences.fromInstance(
+    mostRecentTermsUrlNl: 'testurl',
+    mostRecentTermsUrlEn: 'testurl',
+  );
+  preferences.markLatestTermsAsAccepted(true);
+
   final repository = IrmaRepository(
     client: IrmaMockBridge(),
-    preferences: await IrmaPreferences.fromInstance(),
+    preferences: preferences,
   );
 
   runApp(ProviderScope(child: PrototypesApp(repository: repository)));

--- a/lib/routing.dart
+++ b/lib/routing.dart
@@ -287,24 +287,21 @@ class RedirectionListenable extends ValueNotifier<RedirectionTriggers> {
     final infoStream = repo.getVersionInformation().map<VersionInformation?>((version) => version).defaultIfEmpty(null);
     final nameChangedStream = repo.preferences.getShowNameChangedNotification();
     final enrollmentStream = repo.getEnrollmentStatus();
-    final latestTermsAccepted = repo.preferences.hasAcceptedLatestTerms();
 
     // combine the streams into one
-    _streamSubscription = Rx.combineLatest6(
+    _streamSubscription = Rx.combineLatest5(
       warningStream,
       lockedStream,
       infoStream,
       nameChangedStream,
       enrollmentStream,
-      latestTermsAccepted,
-      (deviceRootedWarning, locked, versionInfo, nameChangedWarning, enrollment, acceptedLatestTerms) {
+      (deviceRootedWarning, locked, versionInfo, nameChangedWarning, enrollment) {
         return RedirectionTriggers(
           appLocked: locked,
           showDeviceRootedWarning: deviceRootedWarning,
           showNameChangedMessage: nameChangedWarning,
           versionInformation: versionInfo,
           enrollmentStatus: enrollment,
-          acceptedLatestTerms: acceptedLatestTerms,
         );
       },
     );
@@ -324,7 +321,6 @@ class RedirectionTriggers {
   final bool showNameChangedMessage;
   final VersionInformation? versionInformation;
   final EnrollmentStatus enrollmentStatus;
-  final bool acceptedLatestTerms;
 
   RedirectionTriggers({
     required this.appLocked,
@@ -332,7 +328,6 @@ class RedirectionTriggers {
     required this.showNameChangedMessage,
     required this.versionInformation,
     required this.enrollmentStatus,
-    required this.acceptedLatestTerms,
   });
 
   RedirectionTriggers.withDefaults()
@@ -340,8 +335,7 @@ class RedirectionTriggers {
         appLocked = true,
         showDeviceRootedWarning = false,
         showNameChangedMessage = false,
-        versionInformation = null,
-        acceptedLatestTerms = false;
+        versionInformation = null;
 
   RedirectionTriggers copyWith({
     bool? appLocked,
@@ -349,7 +343,6 @@ class RedirectionTriggers {
     bool? showNameChangedMessage,
     VersionInformation? versionInformation,
     EnrollmentStatus? enrollmentStatus,
-    bool? acceptedLatestTerms,
   }) {
     return RedirectionTriggers(
       appLocked: appLocked ?? this.appLocked,
@@ -357,7 +350,6 @@ class RedirectionTriggers {
       showNameChangedMessage: showNameChangedMessage ?? this.showNameChangedMessage,
       versionInformation: versionInformation ?? this.versionInformation,
       enrollmentStatus: enrollmentStatus ?? this.enrollmentStatus,
-      acceptedLatestTerms: acceptedLatestTerms ?? this.acceptedLatestTerms,
     );
   }
 
@@ -371,13 +363,12 @@ class RedirectionTriggers {
         showDeviceRootedWarning == other.showDeviceRootedWarning &&
         showNameChangedMessage == other.showNameChangedMessage &&
         versionInformation == other.versionInformation &&
-        enrollmentStatus == other.enrollmentStatus &&
-        acceptedLatestTerms == other.acceptedLatestTerms;
+        enrollmentStatus == other.enrollmentStatus;
   }
 
   @override
   String toString() {
-    return 'lock: $appLocked, enroll: $enrollmentStatus, rooted: $showDeviceRootedWarning, name: $showNameChangedMessage, version: $versionInformation, accept terms: $acceptedLatestTerms';
+    return 'lock: $appLocked, enroll: $enrollmentStatus, rooted: $showDeviceRootedWarning, name: $showNameChangedMessage, version: $versionInformation';
   }
 
   @override
@@ -387,7 +378,6 @@ class RedirectionTriggers {
         showDeviceRootedWarning,
         versionInformation,
         enrollmentStatus,
-        acceptedLatestTerms,
       );
 }
 

--- a/lib/routing.dart
+++ b/lib/routing.dart
@@ -78,10 +78,16 @@ GoRouter createRouter(BuildContext buildContext) {
           return NoTransitionPage(
             name: '/pin',
             child: Builder(builder: (context) {
-              return PinScreen(
-                onAuthenticated: context.goHomeScreenWithoutTransition,
-                leading:
-                    YiviAppBarQrCodeButton(onTap: () => openQrCodeScanner(context, requireAuthBeforeSession: true)),
+              return TermsChangedListener(
+                child: PinScreen(
+                  onAuthenticated: context.goHomeScreenWithoutTransition,
+                  leading: YiviAppBarQrCodeButton(
+                    onTap: () => openQrCodeScanner(
+                      context,
+                      requireAuthBeforeSession: true,
+                    ),
+                  ),
+                ),
               );
             }),
           );
@@ -231,9 +237,6 @@ GoRouter createRouter(BuildContext buildContext) {
     redirect: (context, state) {
       if (redirectionTriggers.value.enrollmentStatus == EnrollmentStatus.unenrolled) {
         return '/enrollment';
-      }
-      if (!redirectionTriggers.value.acceptedLatestTerms) {
-        return '/accept_terms';
       }
       if (redirectionTriggers.value.showDeviceRootedWarning) {
         return '/rooted_warning';

--- a/lib/routing.dart
+++ b/lib/routing.dart
@@ -38,7 +38,7 @@ import 'src/screens/scanner/scanner_screen.dart';
 import 'src/screens/session/session_screen.dart';
 import 'src/screens/session/unknown_session_screen.dart';
 import 'src/screens/settings/settings_screen.dart';
-import 'src/screens/terms_changed/terms_changed_screen.dart';
+import 'src/screens/terms_changed/terms_changed_dialog.dart';
 import 'src/util/navigation.dart';
 import 'src/widgets/irma_app_bar.dart';
 

--- a/lib/routing.dart
+++ b/lib/routing.dart
@@ -69,10 +69,6 @@ GoRouter createRouter(BuildContext buildContext) {
         pageBuilder: (context, state) => NoTransitionPage(name: '/loading', child: LoadingScreen()),
       ),
       GoRoute(
-        path: '/accept_terms',
-        pageBuilder: (context, state) => NoTransitionPage(child: TermsChangedScreen()),
-      ),
-      GoRoute(
         path: '/pin',
         pageBuilder: (context, state) {
           return NoTransitionPage(

--- a/lib/src/data/irma_preferences.dart
+++ b/lib/src/data/irma_preferences.dart
@@ -1,8 +1,13 @@
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
 class IrmaPreferences {
+  // These values should be altered accordingly when the terms change
+  static const mostRecentTermsUrlNl = 'https://www.yivi.app/terms-and-conditionss';
+  static const mostRecentTermsUrlEn = 'https://www.yivi.app/en/terms-and-conditions';
+
   IrmaPreferences(StreamingSharedPreferences preferences)
       : _screenshotsEnabled = preferences.getBool(_screenshotsEnabledKey, defaultValue: false),
+        _acceptedTermsUrl = preferences.getString(_acceptedTermsUrlKey, defaultValue: 'no-terms-accepted'),
         // Please don't arbitrarily change this value, this could hinder the upgrade flow
         // For users before the pin size >5 was introduced.
         _longPin = preferences.getBool(_longPinKey, defaultValue: true),
@@ -64,6 +69,9 @@ class IrmaPreferences {
   static const String _serializedNotificationsKey = 'preference.notifications';
   final Preference<String> _serializedNotifications;
 
+  static const String _acceptedTermsUrlKey = 'preferences.accepted_terms_url';
+  final Preference<String> _acceptedTermsUrl;
+
   // =============================================================================
 
   Stream<bool> getScreenshotsEnabled() => _screenshotsEnabled;
@@ -107,6 +115,11 @@ class IrmaPreferences {
   Stream<String> getSerializedNotifications() => _serializedNotifications;
 
   Future<bool> setSerializedNotifications(String value) => _serializedNotifications.setValue(value);
+
+  Stream<bool> hasAcceptedLatestTerms() => _acceptedTermsUrl.map((url) => url == mostRecentTermsUrlNl);
+
+  Future<bool> markLatestTermsAsAccepted(bool accepted) =>
+      _acceptedTermsUrl.setValue(accepted ? mostRecentTermsUrlNl : 'no-terms-accepted');
 
   Future<void> clearAll() {
     // Reset all preferences to their default values

--- a/lib/src/data/irma_preferences.dart
+++ b/lib/src/data/irma_preferences.dart
@@ -1,12 +1,14 @@
 import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
 class IrmaPreferences {
-  // These values should be altered accordingly when the terms change
-  static const mostRecentTermsUrlNl = 'https://yivi.app/terms_and_conditions_v3/';
-  static const mostRecentTermsUrlEn = 'https://yivi.app/en/terms_and_conditions_v3/';
+  final String mostRecentTermsUrlNl;
+  final String mostRecentTermsUrlEn;
 
-  IrmaPreferences(StreamingSharedPreferences preferences)
-      : _screenshotsEnabled = preferences.getBool(_screenshotsEnabledKey, defaultValue: false),
+  IrmaPreferences(
+    StreamingSharedPreferences preferences, {
+    required this.mostRecentTermsUrlNl,
+    required this.mostRecentTermsUrlEn,
+  })  : _screenshotsEnabled = preferences.getBool(_screenshotsEnabledKey, defaultValue: false),
         _acceptedTermsUrl = preferences.getString(_acceptedTermsUrlKey, defaultValue: 'no-terms-accepted'),
         // Please don't arbitrarily change this value, this could hinder the upgrade flow
         // For users before the pin size >5 was introduced.
@@ -26,7 +28,15 @@ class IrmaPreferences {
     preferences.remove(_developerModePrefVisibleKey);
   }
 
-  static Future<IrmaPreferences> fromInstance() async => IrmaPreferences(await StreamingSharedPreferences.instance);
+  static Future<IrmaPreferences> fromInstance({
+    required String mostRecentTermsUrlNl,
+    required String mostRecentTermsUrlEn,
+  }) async =>
+      IrmaPreferences(
+        await StreamingSharedPreferences.instance,
+        mostRecentTermsUrlNl: mostRecentTermsUrlNl,
+        mostRecentTermsUrlEn: mostRecentTermsUrlEn,
+      );
 
   // =============================================================================
 

--- a/lib/src/data/irma_preferences.dart
+++ b/lib/src/data/irma_preferences.dart
@@ -2,7 +2,7 @@ import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
 class IrmaPreferences {
   // These values should be altered accordingly when the terms change
-  static const mostRecentTermsUrlNl = 'https://www.yivi.app/terms-and-conditionss';
+  static const mostRecentTermsUrlNl = 'https://www.yivi.app/terms-and-conditions';
   static const mostRecentTermsUrlEn = 'https://www.yivi.app/en/terms-and-conditions';
 
   IrmaPreferences(StreamingSharedPreferences preferences)

--- a/lib/src/data/irma_preferences.dart
+++ b/lib/src/data/irma_preferences.dart
@@ -2,8 +2,8 @@ import 'package:streaming_shared_preferences/streaming_shared_preferences.dart';
 
 class IrmaPreferences {
   // These values should be altered accordingly when the terms change
-  static const mostRecentTermsUrlNl = 'https://www.yivi.app/terms-and-conditions';
-  static const mostRecentTermsUrlEn = 'https://www.yivi.app/en/terms-and-conditions';
+  static const mostRecentTermsUrlNl = 'https://yivi.app/terms_and_conditions_v3/';
+  static const mostRecentTermsUrlEn = 'https://yivi.app/en/terms_and_conditions_v3/';
 
   IrmaPreferences(StreamingSharedPreferences preferences)
       : _screenshotsEnabled = preferences.getBool(_screenshotsEnabledKey, defaultValue: false),

--- a/lib/src/screens/enrollment/accept_terms/accept_terms_screen.dart
+++ b/lib/src/screens/enrollment/accept_terms/accept_terms_screen.dart
@@ -7,9 +7,8 @@ import 'widgets/error_reporting_check_box.dart';
 import 'widgets/terms_bullet_list.dart';
 import 'widgets/terms_check_box.dart';
 
+// for first time terms acceptance
 class AcceptTermsScreen extends StatelessWidget {
-  static const String routeName = 'terms';
-
   final bool isAccepted;
   final Function(bool) onToggleAccepted;
   final VoidCallback onContinue;

--- a/lib/src/screens/enrollment/accept_terms/widgets/terms_check_box.dart
+++ b/lib/src/screens/enrollment/accept_terms/widgets/terms_check_box.dart
@@ -1,11 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../../../data/irma_preferences.dart';
+import '../../../../providers/preferences_provider.dart';
 import '../../../../theme/theme.dart';
 import '../../../../widgets/translated_text.dart';
 
-class TermsCheckBox extends StatelessWidget {
+class TermsCheckBox extends ConsumerWidget {
   final bool isAccepted;
   final Function(bool) onToggleAccepted;
 
@@ -15,12 +16,14 @@ class TermsCheckBox extends StatelessWidget {
   });
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final theme = IrmaTheme.of(context);
 
+    final preferences = ref.watch(preferencesProvider);
+
     final termsUrl = (FlutterI18n.currentLocale(context)?.languageCode ?? 'en') == 'nl'
-        ? IrmaPreferences.mostRecentTermsUrlNl
-        : IrmaPreferences.mostRecentTermsUrlEn;
+        ? preferences.mostRecentTermsUrlNl
+        : preferences.mostRecentTermsUrlEn;
 
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,

--- a/lib/src/screens/enrollment/accept_terms/widgets/terms_check_box.dart
+++ b/lib/src/screens/enrollment/accept_terms/widgets/terms_check_box.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_i18n/flutter_i18n.dart';
 
+import '../../../../data/irma_preferences.dart';
 import '../../../../theme/theme.dart';
 import '../../../../widgets/translated_text.dart';
 
@@ -16,6 +18,10 @@ class TermsCheckBox extends StatelessWidget {
   Widget build(BuildContext context) {
     final theme = IrmaTheme.of(context);
 
+    final termsUrl = (FlutterI18n.currentLocale(context)?.languageCode ?? 'en') == 'nl'
+        ? IrmaPreferences.mostRecentTermsUrlNl
+        : IrmaPreferences.mostRecentTermsUrlEn;
+
     return Row(
       crossAxisAlignment: CrossAxisAlignment.center,
       mainAxisAlignment: MainAxisAlignment.start,
@@ -31,9 +37,10 @@ class TermsCheckBox extends StatelessWidget {
         SizedBox(
           width: theme.smallSpacing,
         ),
-        const Flexible(
+        Flexible(
           child: TranslatedText(
             'enrollment.terms_and_conditions.accept_markdown',
+            translationParams: {'terms_url': termsUrl},
           ),
         ),
       ],

--- a/lib/src/screens/enrollment/enrollment_screen.dart
+++ b/lib/src/screens/enrollment/enrollment_screen.dart
@@ -40,9 +40,11 @@ class _ProvidedEnrollmentScreen extends StatelessWidget {
     // we have to await the locked setting, because it could come after the enrollment status,
     // causing us to be automatically redirected to the pin screen when we're already unlocked...
     final locked = await repo.getLocked().first;
+
     if (!context.mounted) {
       return;
     }
+
     if (locked) {
       context.goPinScreen();
     } else {
@@ -128,11 +130,14 @@ class _ProvidedEnrollmentScreen extends StatelessWidget {
             isAccepted: state.isAccepted,
             onPrevious: addOnPreviousPressed,
             onContinue: addOnNextPressed,
-            onToggleAccepted: (isAccepted) => addEvent(
-              EnrollmentTermsUpdated(
-                isAccepted: isAccepted,
-              ),
-            ),
+            onToggleAccepted: (isAccepted) {
+              repo.preferences.markLatestTermsAsAccepted(isAccepted);
+              addEvent(
+                EnrollmentTermsUpdated(
+                  isAccepted: isAccepted,
+                ),
+              );
+            },
           );
         }
         if (state is EnrollmentFailed) {

--- a/lib/src/screens/enrollment/enrollment_screen.dart
+++ b/lib/src/screens/enrollment/enrollment_screen.dart
@@ -132,11 +132,7 @@ class _ProvidedEnrollmentScreen extends StatelessWidget {
             onContinue: addOnNextPressed,
             onToggleAccepted: (isAccepted) {
               repo.preferences.markLatestTermsAsAccepted(isAccepted);
-              addEvent(
-                EnrollmentTermsUpdated(
-                  isAccepted: isAccepted,
-                ),
-              );
+              addEvent(EnrollmentTermsUpdated(isAccepted: isAccepted));
             },
           );
         }

--- a/lib/src/screens/terms_changed/terms_changed_dialog.dart
+++ b/lib/src/screens/terms_changed/terms_changed_dialog.dart
@@ -64,6 +64,8 @@ class _TermsChangedListenerState extends State<TermsChangedListener> {
   }
 }
 
+// ==================================================================================
+
 class TermsChangedDialog extends StatefulWidget {
   const TermsChangedDialog({super.key});
 
@@ -72,8 +74,6 @@ class TermsChangedDialog extends StatefulWidget {
 }
 
 class _TermsChangedDialogState extends State<TermsChangedDialog> {
-  bool viewedNewTerms = false;
-
   @override
   Widget build(BuildContext context) {
     final prefs = IrmaRepositoryProvider.of(context).preferences;
@@ -85,7 +85,7 @@ class _TermsChangedDialogState extends State<TermsChangedDialog> {
     final theme = IrmaTheme.of(context);
 
     return YiviDialog(
-      maxHeight: 500,
+      maxHeight: 400,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -93,7 +93,7 @@ class _TermsChangedDialogState extends State<TermsChangedDialog> {
             titleTranslationKey: 'new_terms_and_conditions.title',
             leading: null,
           ),
-          Padding(
+          SingleChildScrollView(
             padding: EdgeInsets.all(theme.defaultSpacing),
             child: Column(
               mainAxisAlignment: MainAxisAlignment.center,
@@ -102,15 +102,12 @@ class _TermsChangedDialogState extends State<TermsChangedDialog> {
                   'new_terms_and_conditions.explanation',
                   textAlign: TextAlign.center,
                 ),
-                SizedBox(height: theme.hugeSpacing),
+                SizedBox(height: theme.mediumSpacing),
                 CupertinoTheme(
                   data: CupertinoThemeData(primaryColor: theme.link),
                   child: CupertinoButton(
                     onPressed: () {
                       IrmaRepositoryProvider.of(context).openURL(termsUrl);
-                      setState(() {
-                        viewedNewTerms = true;
-                      });
                     },
                     child: TranslatedText('new_terms_and_conditions.read_terms'),
                   ),
@@ -121,14 +118,12 @@ class _TermsChangedDialogState extends State<TermsChangedDialog> {
           IrmaBottomBar(
             primaryButtonLabel: 'new_terms_and_conditions.accept',
             secondaryButtonLabel: 'new_terms_and_conditions.dismiss',
-            onPrimaryPressed: viewedNewTerms
-                ? () async {
-                    await prefs.markLatestTermsAsAccepted(true);
-                    if (context.mounted) {
-                      context.pop();
-                    }
-                  }
-                : null,
+            onPrimaryPressed: () async {
+              await prefs.markLatestTermsAsAccepted(true);
+              if (context.mounted) {
+                context.pop();
+              }
+            },
             onSecondaryPressed: () {
               context.pop();
             },

--- a/lib/src/screens/terms_changed/terms_changed_dialog.dart
+++ b/lib/src/screens/terms_changed/terms_changed_dialog.dart
@@ -83,15 +83,13 @@ class _TermsChangedDialogState extends ConsumerState<TermsChangedDialog> {
   Widget build(BuildContext context) {
     final prefs = ref.watch(preferencesProvider);
 
-    final termsUrl = (FlutterI18n.currentLocale(context)?.languageCode ?? 'en') == 'nl'
-        ? prefs.mostRecentTermsUrlNl
-        : prefs.mostRecentTermsUrlEn;
+    final isDutch = (FlutterI18n.currentLocale(context)?.languageCode ?? 'en') == 'nl';
+    final termsUrl = isDutch ? prefs.mostRecentTermsUrlNl : prefs.mostRecentTermsUrlEn;
 
     final theme = IrmaTheme.of(context);
 
     return YiviDialog(
       key: const Key('terms_changed_dialog'),
-      maxHeight: 400,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,
         children: [
@@ -99,30 +97,12 @@ class _TermsChangedDialogState extends ConsumerState<TermsChangedDialog> {
             titleTranslationKey: 'new_terms_and_conditions.title',
             leading: null,
           ),
-          Expanded(
-            child: SingleChildScrollView(
-              padding: EdgeInsets.all(theme.defaultSpacing),
-              child: Column(
-                children: [
-                  TranslatedText(
-                    'new_terms_and_conditions.explanation',
-                    textAlign: TextAlign.center,
-                  ),
-                  SizedBox(height: theme.mediumSpacing),
-                  CupertinoTheme(
-                    data: CupertinoThemeData(primaryColor: theme.link),
-                    child: CupertinoButton(
-                      onPressed: () {
-                        IrmaRepositoryProvider.of(context).openURL(termsUrl);
-                      },
-                      child: TranslatedText(
-                        'new_terms_and_conditions.read_terms',
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
-                  ),
-                ],
-              ),
+          SingleChildScrollView(
+            padding: EdgeInsets.all(theme.defaultSpacing),
+            child: TranslatedText(
+              'new_terms_and_conditions.explanation_markdown',
+              translationParams: {'terms_url': termsUrl},
+              markdownTextAlign: WrapAlignment.center,
             ),
           ),
           IrmaBottomBar(

--- a/lib/src/screens/terms_changed/terms_changed_dialog.dart
+++ b/lib/src/screens/terms_changed/terms_changed_dialog.dart
@@ -86,6 +86,7 @@ class _TermsChangedDialogState extends ConsumerState<TermsChangedDialog> {
     final theme = IrmaTheme.of(context);
 
     return YiviDialog(
+      key: const Key('terms_changed_dialog'),
       maxHeight: 400,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.spaceBetween,

--- a/lib/src/screens/terms_changed/terms_changed_dialog.dart
+++ b/lib/src/screens/terms_changed/terms_changed_dialog.dart
@@ -27,6 +27,7 @@ class TermsChangedListener extends ConsumerStatefulWidget {
 
 class _TermsChangedListenerState extends ConsumerState<TermsChangedListener> {
   StreamSubscription<bool>? _subscription;
+  bool _dialogActive = false;
 
   @override
   void didChangeDependencies() {
@@ -38,14 +39,17 @@ class _TermsChangedListenerState extends ConsumerState<TermsChangedListener> {
     final stream = preferences.hasAcceptedLatestTerms();
 
     _subscription = stream.listen(
-      (accepted) {
-        if (!accepted && mounted) {
-          showDialog(
+      (accepted) async {
+        if (!accepted && mounted && !_dialogActive) {
+          // making sure the dialog is only showing once, not in a stack...
+          _dialogActive = true;
+          await showDialog(
             context: context,
             builder: (context) {
               return TermsChangedDialog();
             },
           );
+          _dialogActive = false;
         }
       },
     );

--- a/lib/src/screens/terms_changed/terms_changed_dialog.dart
+++ b/lib/src/screens/terms_changed/terms_changed_dialog.dart
@@ -3,32 +3,30 @@ import 'dart:async';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../data/irma_preferences.dart';
 import '../../providers/irma_repository_provider.dart';
+import '../../providers/preferences_provider.dart';
 import '../../theme/theme.dart';
 import '../../widgets/irma_app_bar.dart';
 import '../../widgets/irma_bottom_bar.dart';
 import '../../widgets/irma_dialog.dart';
 import '../../widgets/translated_text.dart';
 
-class TermsChangedListener extends StatefulWidget {
+class TermsChangedListener extends ConsumerStatefulWidget {
   const TermsChangedListener({required this.child});
 
   final Widget child;
 
   @override
-  State<TermsChangedListener> createState() => _TermsChangedListenerState();
+  ConsumerState<ConsumerStatefulWidget> createState() {
+    return _TermsChangedListenerState();
+  }
 }
 
-class _TermsChangedListenerState extends State<TermsChangedListener> {
+class _TermsChangedListenerState extends ConsumerState<TermsChangedListener> {
   StreamSubscription<bool>? _subscription;
-
-  @override
-  void initState() {
-    super.initState();
-  }
 
   @override
   void didChangeDependencies() {
@@ -36,7 +34,8 @@ class _TermsChangedListenerState extends State<TermsChangedListener> {
 
     _subscription?.cancel();
 
-    final stream = IrmaRepositoryProvider.of(context).preferences.hasAcceptedLatestTerms();
+    final preferences = ref.read(preferencesProvider);
+    final stream = preferences.hasAcceptedLatestTerms();
 
     _subscription = stream.listen(
       (accepted) {
@@ -66,21 +65,23 @@ class _TermsChangedListenerState extends State<TermsChangedListener> {
 
 // ==================================================================================
 
-class TermsChangedDialog extends StatefulWidget {
+class TermsChangedDialog extends ConsumerStatefulWidget {
   const TermsChangedDialog({super.key});
 
   @override
-  State<TermsChangedDialog> createState() => _TermsChangedDialogState();
+  ConsumerState<ConsumerStatefulWidget> createState() {
+    return _TermsChangedDialogState();
+  }
 }
 
-class _TermsChangedDialogState extends State<TermsChangedDialog> {
+class _TermsChangedDialogState extends ConsumerState<TermsChangedDialog> {
   @override
   Widget build(BuildContext context) {
-    final prefs = IrmaRepositoryProvider.of(context).preferences;
+    final prefs = ref.watch(preferencesProvider);
 
     final termsUrl = (FlutterI18n.currentLocale(context)?.languageCode ?? 'en') == 'nl'
-        ? IrmaPreferences.mostRecentTermsUrlNl
-        : IrmaPreferences.mostRecentTermsUrlEn;
+        ? prefs.mostRecentTermsUrlNl
+        : prefs.mostRecentTermsUrlEn;
 
     final theme = IrmaTheme.of(context);
 

--- a/lib/src/screens/terms_changed/terms_changed_dialog.dart
+++ b/lib/src/screens/terms_changed/terms_changed_dialog.dart
@@ -1,12 +1,10 @@
 import 'dart:async';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../../providers/irma_repository_provider.dart';
 import '../../providers/preferences_provider.dart';
 import '../../theme/theme.dart';
 import '../../widgets/irma_app_bar.dart';
@@ -121,7 +119,5 @@ class _TermsChangedDialogState extends ConsumerState<TermsChangedDialog> {
         ],
       ),
     );
-
-    // return ;
   }
 }

--- a/lib/src/screens/terms_changed/terms_changed_dialog.dart
+++ b/lib/src/screens/terms_changed/terms_changed_dialog.dart
@@ -99,26 +99,30 @@ class _TermsChangedDialogState extends ConsumerState<TermsChangedDialog> {
             titleTranslationKey: 'new_terms_and_conditions.title',
             leading: null,
           ),
-          SingleChildScrollView(
-            padding: EdgeInsets.all(theme.defaultSpacing),
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                TranslatedText(
-                  'new_terms_and_conditions.explanation',
-                  textAlign: TextAlign.center,
-                ),
-                SizedBox(height: theme.mediumSpacing),
-                CupertinoTheme(
-                  data: CupertinoThemeData(primaryColor: theme.link),
-                  child: CupertinoButton(
-                    onPressed: () {
-                      IrmaRepositoryProvider.of(context).openURL(termsUrl);
-                    },
-                    child: TranslatedText('new_terms_and_conditions.read_terms'),
+          Expanded(
+            child: SingleChildScrollView(
+              padding: EdgeInsets.all(theme.defaultSpacing),
+              child: Column(
+                children: [
+                  TranslatedText(
+                    'new_terms_and_conditions.explanation',
+                    textAlign: TextAlign.center,
                   ),
-                ),
-              ],
+                  SizedBox(height: theme.mediumSpacing),
+                  CupertinoTheme(
+                    data: CupertinoThemeData(primaryColor: theme.link),
+                    child: CupertinoButton(
+                      onPressed: () {
+                        IrmaRepositoryProvider.of(context).openURL(termsUrl);
+                      },
+                      child: TranslatedText(
+                        'new_terms_and_conditions.read_terms',
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
             ),
           ),
           IrmaBottomBar(

--- a/lib/src/screens/terms_changed/terms_changed_screen.dart
+++ b/lib/src/screens/terms_changed/terms_changed_screen.dart
@@ -1,0 +1,110 @@
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:go_router/go_router.dart';
+
+import '../../data/irma_preferences.dart';
+import '../../models/clear_all_data_event.dart';
+import '../../models/translated_value.dart';
+import '../../providers/irma_repository_provider.dart';
+import '../../theme/theme.dart';
+import '../../util/navigation.dart';
+import '../../widgets/irma_app_bar.dart';
+import '../../widgets/irma_bottom_bar.dart';
+import '../../widgets/irma_confirmation_dialog.dart';
+import '../../widgets/translated_text.dart';
+import '../../widgets/yivi_themed_button.dart';
+
+// Screen to show when terms and conditions have changed
+class TermsChangedScreen extends StatefulWidget {
+  const TermsChangedScreen({super.key});
+
+  @override
+  State<TermsChangedScreen> createState() => _TermsChangedScreenState();
+}
+
+class _TermsChangedScreenState extends State<TermsChangedScreen> {
+  bool viewedNewTerms = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final prefs = IrmaRepositoryProvider.of(context).preferences;
+
+    final termsUrl = (FlutterI18n.currentLocale(context)?.languageCode ?? 'en') == 'nl'
+        ? IrmaPreferences.mostRecentTermsUrlNl
+        : IrmaPreferences.mostRecentTermsUrlEn;
+
+    final theme = IrmaTheme.of(context);
+
+    return PopScope(
+      canPop: false,
+      child: Scaffold(
+        appBar: IrmaAppBar(
+          titleTranslationKey: 'new_terms_and_conditions.title',
+          leading: null,
+        ),
+        body: Padding(
+          padding: EdgeInsets.all(theme.defaultSpacing),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              TranslatedText(
+                'new_terms_and_conditions.explanation',
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: theme.hugeSpacing),
+              CupertinoTheme(
+                data: CupertinoThemeData(primaryColor: theme.link),
+                child: CupertinoButton(
+                  onPressed: () {
+                    IrmaRepositoryProvider.of(context).openURL(termsUrl);
+                    setState(() {
+                      viewedNewTerms = true;
+                    });
+                  },
+                  child: TranslatedText('new_terms_and_conditions.read_terms'),
+                ),
+              ),
+            ],
+          ),
+        ),
+        bottomNavigationBar: IrmaBottomBar(
+          primaryButtonLabel: 'new_terms_and_conditions.accept',
+          secondaryButtonLabel: 'new_terms_and_conditions.reject',
+          onPrimaryPressed: viewedNewTerms
+              ? () async {
+                  debugPrint('marking as accepted');
+                  await prefs.markLatestTermsAsAccepted(true);
+                  if (context.mounted) {
+                    debugPrint('go to  home');
+                    context.goHomeScreenWithoutTransition();
+                  }
+                }
+              : null,
+          onSecondaryPressed: () async {
+            final userConfirmsDelete = await showDialog<bool>(
+                  context: context,
+                  builder: (context) {
+                    return IrmaConfirmationDialog(
+                      titleTranslationKey: 'new_terms_and_conditions.reject_dialog.title',
+                      contentTranslationKey: 'new_terms_and_conditions.reject_dialog.body',
+                      cancelTranslationKey: 'new_terms_and_conditions.reject_dialog.cancel',
+                      confirmTranslationKey: 'new_terms_and_conditions.reject_dialog.delete',
+                      onCancelPressed: () => context.pop(false),
+                      onConfirmPressed: () => context.pop(true),
+                    );
+                  },
+                ) ??
+                false;
+
+            if (userConfirmsDelete && context.mounted) {
+              IrmaRepositoryProvider.of(context).bridgedDispatch(
+                ClearAllDataEvent(),
+              );
+            }
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/src/screens/terms_changed/terms_changed_screen.dart
+++ b/lib/src/screens/terms_changed/terms_changed_screen.dart
@@ -6,12 +6,10 @@ import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:go_router/go_router.dart';
 
 import '../../data/irma_preferences.dart';
-import '../../models/clear_all_data_event.dart';
 import '../../providers/irma_repository_provider.dart';
 import '../../theme/theme.dart';
 import '../../widgets/irma_app_bar.dart';
 import '../../widgets/irma_bottom_bar.dart';
-import '../../widgets/irma_confirmation_dialog.dart';
 import '../../widgets/irma_dialog.dart';
 import '../../widgets/translated_text.dart';
 
@@ -140,94 +138,5 @@ class _TermsChangedDialogState extends State<TermsChangedDialog> {
     );
 
     // return ;
-  }
-}
-
-// Screen to show when terms and conditions have changed
-class TermsChangedScreen extends StatefulWidget {
-  const TermsChangedScreen({super.key});
-
-  @override
-  State<TermsChangedScreen> createState() => _TermsChangedScreenState();
-}
-
-class _TermsChangedScreenState extends State<TermsChangedScreen> {
-  bool viewedNewTerms = false;
-
-  @override
-  Widget build(BuildContext context) {
-    final prefs = IrmaRepositoryProvider.of(context).preferences;
-
-    final termsUrl = (FlutterI18n.currentLocale(context)?.languageCode ?? 'en') == 'nl'
-        ? IrmaPreferences.mostRecentTermsUrlNl
-        : IrmaPreferences.mostRecentTermsUrlEn;
-
-    final theme = IrmaTheme.of(context);
-
-    return PopScope(
-      canPop: false,
-      child: Scaffold(
-        appBar: IrmaAppBar(
-          titleTranslationKey: 'new_terms_and_conditions.title',
-          leading: null,
-        ),
-        body: Padding(
-          padding: EdgeInsets.all(theme.defaultSpacing),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: [
-              TranslatedText(
-                'new_terms_and_conditions.explanation',
-                textAlign: TextAlign.center,
-              ),
-              SizedBox(height: theme.hugeSpacing),
-              CupertinoTheme(
-                data: CupertinoThemeData(primaryColor: theme.link),
-                child: CupertinoButton(
-                  onPressed: () {
-                    IrmaRepositoryProvider.of(context).openURL(termsUrl);
-                    setState(() {
-                      viewedNewTerms = true;
-                    });
-                  },
-                  child: TranslatedText('new_terms_and_conditions.read_terms'),
-                ),
-              ),
-            ],
-          ),
-        ),
-        bottomNavigationBar: IrmaBottomBar(
-          primaryButtonLabel: 'new_terms_and_conditions.accept',
-          secondaryButtonLabel: 'new_terms_and_conditions.reject',
-          onPrimaryPressed: viewedNewTerms
-              ? () async {
-                  await prefs.markLatestTermsAsAccepted(true);
-                }
-              : null,
-          onSecondaryPressed: () async {
-            final userConfirmsDelete = await showDialog<bool>(
-                  context: context,
-                  builder: (context) {
-                    return IrmaConfirmationDialog(
-                      titleTranslationKey: 'new_terms_and_conditions.reject_dialog.title',
-                      contentTranslationKey: 'new_terms_and_conditions.reject_dialog.body',
-                      cancelTranslationKey: 'new_terms_and_conditions.reject_dialog.cancel',
-                      confirmTranslationKey: 'new_terms_and_conditions.reject_dialog.delete',
-                      onCancelPressed: () => context.pop(false),
-                      onConfirmPressed: () => context.pop(true),
-                    );
-                  },
-                ) ??
-                false;
-
-            if (userConfirmsDelete && context.mounted) {
-              IrmaRepositoryProvider.of(context).bridgedDispatch(
-                ClearAllDataEvent(),
-              );
-            }
-          },
-        ),
-      ),
-    );
   }
 }

--- a/lib/src/screens/terms_changed/terms_changed_screen.dart
+++ b/lib/src/screens/terms_changed/terms_changed_screen.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
@@ -7,11 +9,139 @@ import '../../data/irma_preferences.dart';
 import '../../models/clear_all_data_event.dart';
 import '../../providers/irma_repository_provider.dart';
 import '../../theme/theme.dart';
-import '../../util/navigation.dart';
 import '../../widgets/irma_app_bar.dart';
 import '../../widgets/irma_bottom_bar.dart';
 import '../../widgets/irma_confirmation_dialog.dart';
+import '../../widgets/irma_dialog.dart';
 import '../../widgets/translated_text.dart';
+
+class TermsChangedListener extends StatefulWidget {
+  const TermsChangedListener({required this.child});
+
+  final Widget child;
+
+  @override
+  State<TermsChangedListener> createState() => _TermsChangedListenerState();
+}
+
+class _TermsChangedListenerState extends State<TermsChangedListener> {
+  StreamSubscription<bool>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+
+    _subscription?.cancel();
+
+    final stream = IrmaRepositoryProvider.of(context).preferences.hasAcceptedLatestTerms();
+
+    _subscription = stream.listen(
+      (accepted) {
+        if (!accepted && mounted) {
+          showDialog(
+            context: context,
+            builder: (context) {
+              return TermsChangedDialog();
+            },
+          );
+        }
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _subscription?.cancel();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return widget.child;
+  }
+}
+
+class TermsChangedDialog extends StatefulWidget {
+  const TermsChangedDialog({super.key});
+
+  @override
+  State<TermsChangedDialog> createState() => _TermsChangedDialogState();
+}
+
+class _TermsChangedDialogState extends State<TermsChangedDialog> {
+  bool viewedNewTerms = false;
+
+  @override
+  Widget build(BuildContext context) {
+    final prefs = IrmaRepositoryProvider.of(context).preferences;
+
+    final termsUrl = (FlutterI18n.currentLocale(context)?.languageCode ?? 'en') == 'nl'
+        ? IrmaPreferences.mostRecentTermsUrlNl
+        : IrmaPreferences.mostRecentTermsUrlEn;
+
+    final theme = IrmaTheme.of(context);
+
+    return YiviDialog(
+      maxHeight: 500,
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        children: [
+          IrmaAppBar(
+            titleTranslationKey: 'new_terms_and_conditions.title',
+            leading: null,
+          ),
+          Padding(
+            padding: EdgeInsets.all(theme.defaultSpacing),
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                TranslatedText(
+                  'new_terms_and_conditions.explanation',
+                  textAlign: TextAlign.center,
+                ),
+                SizedBox(height: theme.hugeSpacing),
+                CupertinoTheme(
+                  data: CupertinoThemeData(primaryColor: theme.link),
+                  child: CupertinoButton(
+                    onPressed: () {
+                      IrmaRepositoryProvider.of(context).openURL(termsUrl);
+                      setState(() {
+                        viewedNewTerms = true;
+                      });
+                    },
+                    child: TranslatedText('new_terms_and_conditions.read_terms'),
+                  ),
+                ),
+              ],
+            ),
+          ),
+          IrmaBottomBar(
+            primaryButtonLabel: 'new_terms_and_conditions.accept',
+            secondaryButtonLabel: 'new_terms_and_conditions.dismiss',
+            onPrimaryPressed: viewedNewTerms
+                ? () async {
+                    await prefs.markLatestTermsAsAccepted(true);
+                    if (context.mounted) {
+                      context.pop();
+                    }
+                  }
+                : null,
+            onSecondaryPressed: () {
+              context.pop();
+            },
+          ),
+        ],
+      ),
+    );
+
+    // return ;
+  }
+}
 
 // Screen to show when terms and conditions have changed
 class TermsChangedScreen extends StatefulWidget {
@@ -71,12 +201,7 @@ class _TermsChangedScreenState extends State<TermsChangedScreen> {
           secondaryButtonLabel: 'new_terms_and_conditions.reject',
           onPrimaryPressed: viewedNewTerms
               ? () async {
-                  debugPrint('marking as accepted');
                   await prefs.markLatestTermsAsAccepted(true);
-                  if (context.mounted) {
-                    debugPrint('go to  home');
-                    context.goHomeScreenWithoutTransition();
-                  }
                 }
               : null,
           onSecondaryPressed: () async {

--- a/lib/src/screens/terms_changed/terms_changed_screen.dart
+++ b/lib/src/screens/terms_changed/terms_changed_screen.dart
@@ -5,7 +5,6 @@ import 'package:go_router/go_router.dart';
 
 import '../../data/irma_preferences.dart';
 import '../../models/clear_all_data_event.dart';
-import '../../models/translated_value.dart';
 import '../../providers/irma_repository_provider.dart';
 import '../../theme/theme.dart';
 import '../../util/navigation.dart';
@@ -13,7 +12,6 @@ import '../../widgets/irma_app_bar.dart';
 import '../../widgets/irma_bottom_bar.dart';
 import '../../widgets/irma_confirmation_dialog.dart';
 import '../../widgets/translated_text.dart';
-import '../../widgets/yivi_themed_button.dart';
 
 // Screen to show when terms and conditions have changed
 class TermsChangedScreen extends StatefulWidget {

--- a/lib/src/widgets/irma_dialog.dart
+++ b/lib/src/widgets/irma_dialog.dart
@@ -41,7 +41,10 @@ class YiviDialog extends StatelessWidget {
                   borderRadius: BorderRadius.circular(theme.smallSpacing),
                 ),
                 type: MaterialType.card,
-                child: child,
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(theme.smallSpacing),
+                  child: child,
+                ),
               ),
             ),
           ),

--- a/lib/src/widgets/irma_dialog.dart
+++ b/lib/src/widgets/irma_dialog.dart
@@ -5,6 +5,52 @@ import 'package:flutter_i18n/flutter_i18n.dart';
 
 import '../theme/theme.dart';
 
+class YiviDialog extends StatelessWidget {
+  const YiviDialog({super.key, required this.child, this.maxHeight});
+  final Widget child;
+  final double? maxHeight;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = IrmaTheme.of(context);
+
+    return AnimatedPadding(
+      padding: MediaQuery.of(context).viewInsets +
+          EdgeInsets.symmetric(
+            horizontal: theme.mediumSpacing,
+            vertical: theme.defaultSpacing,
+          ),
+      duration: const Duration(milliseconds: 100),
+      curve: Curves.decelerate,
+      child: MediaQuery.removeViewInsets(
+        removeLeft: true,
+        removeTop: true,
+        removeRight: true,
+        removeBottom: true,
+        context: context,
+        child: Center(
+          child: ConstrainedBox(
+            constraints: BoxConstraints(minWidth: 280.0, maxHeight: maxHeight ?? double.infinity),
+            child: Semantics(
+              scopesRoute: true,
+              explicitChildNodes: true,
+              child: Material(
+                color: theme.surfacePrimary,
+                elevation: 24.0,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(theme.smallSpacing),
+                ),
+                type: MaterialType.card,
+                child: child,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class IrmaDialog extends StatelessWidget {
   final String title;
   final String content;

--- a/lib/src/widgets/irma_dialog.dart
+++ b/lib/src/widgets/irma_dialog.dart
@@ -6,9 +6,8 @@ import 'package:flutter_i18n/flutter_i18n.dart';
 import '../theme/theme.dart';
 
 class YiviDialog extends StatelessWidget {
-  const YiviDialog({super.key, required this.child, this.maxHeight});
+  const YiviDialog({super.key, required this.child});
   final Widget child;
-  final double? maxHeight;
 
   @override
   Widget build(BuildContext context) {
@@ -29,24 +28,26 @@ class YiviDialog extends StatelessWidget {
         removeBottom: true,
         context: context,
         child: Center(
-          child: ConstrainedBox(
-            constraints: BoxConstraints(minWidth: 280.0, maxHeight: maxHeight ?? double.infinity),
-            child: Semantics(
-              scopesRoute: true,
-              explicitChildNodes: true,
-              child: Material(
-                color: theme.surfacePrimary,
-                elevation: 24.0,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(theme.smallSpacing),
-                ),
-                type: MaterialType.card,
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(theme.smallSpacing),
-                  child: child,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Semantics(
+                scopesRoute: true,
+                explicitChildNodes: true,
+                child: Material(
+                  color: theme.surfacePrimary,
+                  elevation: 24.0,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(theme.smallSpacing),
+                  ),
+                  type: MaterialType.card,
+                  child: ClipRRect(
+                    borderRadius: BorderRadius.circular(theme.smallSpacing),
+                    child: child,
+                  ),
                 ),
               ),
-            ),
+            ],
           ),
         ),
       ),

--- a/lib/src/widgets/translated_text.dart
+++ b/lib/src/widgets/translated_text.dart
@@ -15,6 +15,7 @@ class TranslatedText extends StatelessWidget {
 
   // Text only
   final TextAlign? textAlign;
+  final WrapAlignment markdownTextAlign;
 
   const TranslatedText(
     this._key, {
@@ -24,6 +25,7 @@ class TranslatedText extends StatelessWidget {
     this.translationParams,
     this.style,
     this.textAlign,
+    this.markdownTextAlign = WrapAlignment.start,
     this.maxLines,
     this.isHeader = false,
   });
@@ -32,6 +34,7 @@ class TranslatedText extends StatelessWidget {
     return IrmaMarkdown(
       translation,
       styleSheet: MarkdownStyleSheet(
+        textAlign: markdownTextAlign,
         p: style,
       ),
     );

--- a/test/disclosure_permission_bloc_test.dart
+++ b/test/disclosure_permission_bloc_test.dart
@@ -22,10 +22,14 @@ void main() {
   setUp(() async {
     mockBridge = IrmaMockBridge();
     SharedPreferences.setMockInitialValues({});
-    repo = IrmaRepository(
-      client: mockBridge,
-      preferences: await IrmaPreferences.fromInstance(),
+
+    final preferences = await IrmaPreferences.fromInstance(
+      mostRecentTermsUrlNl: 'testurl',
+      mostRecentTermsUrlEn: 'testurl',
     );
+    preferences.markLatestTermsAsAccepted(true);
+
+    repo = IrmaRepository(client: mockBridge, preferences: preferences);
     await repo.getCredentials().first; // Wait until AppReadyEvent has been processed.
   });
   tearDown(() async {

--- a/test/notifications_bloc_test.dart
+++ b/test/notifications_bloc_test.dart
@@ -21,15 +21,16 @@ void main() {
   setUp(() async {
     mockBridge = IrmaMockBridge();
     SharedPreferences.setMockInitialValues({});
-    final preferences =
-        await IrmaPreferences.fromInstance(mostRecentTermsUrlNl: 'testurl', mostRecentTermsUrlEn: 'testurl');
+    final preferences = await IrmaPreferences.fromInstance(
+      mostRecentTermsUrlNl: 'testurl',
+      mostRecentTermsUrlEn: 'testurl',
+    );
     preferences.markLatestTermsAsAccepted(true);
 
-    repo = IrmaRepository(
-      client: mockBridge,
-      preferences: preferences,
-    );
-    await repo.getCredentials().first; // Wait until AppReadyEvent has been processed.
+    repo = IrmaRepository(client: mockBridge, preferences: preferences);
+
+    // Wait until AppReadyEvent has been processed.
+    await repo.getCredentials().first;
   });
 
   tearDown(() async {

--- a/test/notifications_bloc_test.dart
+++ b/test/notifications_bloc_test.dart
@@ -21,10 +21,13 @@ void main() {
   setUp(() async {
     mockBridge = IrmaMockBridge();
     SharedPreferences.setMockInitialValues({});
+    final preferences =
+        await IrmaPreferences.fromInstance(mostRecentTermsUrlNl: 'testurl', mostRecentTermsUrlEn: 'testurl');
+    preferences.markLatestTermsAsAccepted(true);
 
     repo = IrmaRepository(
       client: mockBridge,
-      preferences: await IrmaPreferences.fromInstance(),
+      preferences: preferences,
     );
     await repo.getCredentials().first; // Wait until AppReadyEvent has been processed.
   });

--- a/test/session_repository_test.dart
+++ b/test/session_repository_test.dart
@@ -16,10 +16,12 @@ void main() {
   setUp(() async {
     mockBridge = IrmaMockBridge();
     SharedPreferences.setMockInitialValues({});
-    repo = IrmaRepository(
-      client: mockBridge,
-      preferences: await IrmaPreferences.fromInstance(),
+    final preferences = await IrmaPreferences.fromInstance(
+      mostRecentTermsUrlEn: 'testurl',
+      mostRecentTermsUrlNl: 'testurl',
     );
+    preferences.markLatestTermsAsAccepted(true);
+    repo = IrmaRepository(client: mockBridge, preferences: preferences);
   });
   tearDown(() async {
     await mockBridge.close();


### PR DESCRIPTION
Fixes #361 

Users will see a dialog with a prompt to accept to new terms whenever the pin screen is shown.
This dialog can be dismissed, but it will then show again until it is accepted. The dialog also contains a button to open the terms in the browser. Once accepted it will not be shown again until a new app update changes the value of 
`IrmaPreferences.mostRecentTermsUrlNl`. 

This is what it looks like in the app:
<img src="https://github.com/user-attachments/assets/1dcd2b54-8e49-4d3c-8697-f56c235eff65" width="300">

