### PR TITLE
Fix PIN input race conditions

### DIFF
--- a/yivi_core/lib/src/screens/pin/bloc/enter_pin_state.dart
+++ b/yivi_core/lib/src/screens/pin/bloc/enter_pin_state.dart
@@ -108,19 +108,18 @@ class EnterPinState {
 
 class EnterPinStateBloc extends Bloc<int, EnterPinState> {
   final int maxPinSize;
-  EnterPinStateBloc(this.maxPinSize) : super(EnterPinState.empty());
+  EnterPinStateBloc(this.maxPinSize) : super(EnterPinState.empty()) {
+    on<int>((event, emit) {
+      Pin pin = Pin.from(state.pin);
 
-  @override
-  Stream<EnterPinState> mapEventToState(int event) async* {
-    Pin pin = Pin.from(state.pin);
+      if (event >= 0 && event < 10 && state.pin.length < maxPinSize) {
+        pin.add(event);
+      } else if (event.isNegative && state.pin.isNotEmpty) {
+        pin.removeLast();
+      }
 
-    if (event >= 0 && event < 10 && state.pin.length < maxPinSize) {
-      pin.add(event);
-    } else if (event.isNegative && state.pin.isNotEmpty) {
-      pin.removeLast();
-    }
-
-    yield EnterPinState.createFrom(pin: pin);
+      emit(EnterPinState.createFrom(pin: pin));
+    });
   }
 }
 
@@ -128,15 +127,14 @@ class EnterPinStateBloc extends Bloc<int, EnterPinState> {
 class TestEnterPinStateBloc extends Bloc<Pin, EnterPinState> {
   final int maxPinSize;
 
-  TestEnterPinStateBloc(this.maxPinSize) : super(EnterPinState.empty());
+  TestEnterPinStateBloc(this.maxPinSize) : super(EnterPinState.empty()) {
+    on<Pin>((event, emit) {
+      emit(EnterPinState.createFrom(pin: event));
+    });
+  }
 
   @override
   void add(Pin event) {
     super.add(event.length > maxPinSize ? event.sublist(0, maxPinSize) : event);
-  }
-
-  @override
-  Stream<EnterPinState> mapEventToState(Pin event) async* {
-    yield EnterPinState.createFrom(pin: event);
   }
 }

--- a/yivi_core/lib/src/screens/pin/pin_screen.dart
+++ b/yivi_core/lib/src/screens/pin/pin_screen.dart
@@ -35,6 +35,8 @@ class PinScreen extends StatefulWidget {
 
 class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
   late final PinBloc _pinBloc;
+  EnterPinStateBloc? _enterPinBloc;
+  int? _currentMaxPinSize;
 
   StreamSubscription? _pinBlocSubscription;
 
@@ -75,6 +77,7 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
       if (pinState.authenticated) {
         _pinBlocSubscription?.cancel();
       } else if (pinState.pinInvalid) {
+        _resetEnterPinBloc();
         final secondsBlocked =
             pinState.blockedUntil?.difference(DateTime.now()).inSeconds ?? 0;
         if (pinState.remainingAttempts != null &&
@@ -84,6 +87,7 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
           _showBlockedDialog(secondsBlocked);
         }
       } else if (pinState.error != null) {
+        _resetEnterPinBloc();
         _goToSessionErrorScreen(pinState);
       }
       if (!pinState.authenticated) {
@@ -140,8 +144,25 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
     );
   }
 
+  EnterPinStateBloc _getOrCreateEnterPinBloc(int maxPinSize) {
+    if (_enterPinBloc == null || _currentMaxPinSize != maxPinSize) {
+      _enterPinBloc?.close();
+      _enterPinBloc = EnterPinStateBloc(maxPinSize);
+      _currentMaxPinSize = maxPinSize;
+    }
+    return _enterPinBloc!;
+  }
+
+  void _resetEnterPinBloc() {
+    if (_enterPinBloc != null && _currentMaxPinSize != null) {
+      _enterPinBloc!.close();
+      _enterPinBloc = EnterPinStateBloc(_currentMaxPinSize!);
+    }
+  }
+
   @override
   void dispose() {
+    _enterPinBloc?.close();
     _pinBloc.close();
     WidgetsBinding.instance.removeObserver(this);
     super.dispose();
@@ -202,7 +223,7 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
                           ? longPinSize
                           : shortPinSize;
 
-                      final pinBloc = EnterPinStateBloc(maxPinSize);
+                      final pinBloc = _getOrCreateEnterPinBloc(maxPinSize);
 
                       final enabled =
                           (blockedFor.data ?? Duration.zero).inSeconds <= 0 &&

--- a/yivi_core/lib/src/screens/pin/session_pin_screen.dart
+++ b/yivi_core/lib/src/screens/pin/session_pin_screen.dart
@@ -37,6 +37,8 @@ class _SessionPinScreenState extends State<SessionPinScreen>
   late final IrmaRepository _repo;
   late final PinBloc _pinBloc;
   final _navigatorKey = GlobalKey();
+  EnterPinStateBloc? _enterPinBloc;
+  int? _currentMaxPinSize;
 
   StreamSubscription? _pinBlocSubscription;
 
@@ -49,9 +51,11 @@ class _SessionPinScreenState extends State<SessionPinScreen>
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _pinBlocSubscription = _pinBloc.stream.listen((pinState) async {
         if (pinState.pinInvalid) {
+          _resetEnterPinBloc();
           _handleInvalidPin(pinState);
           HapticFeedback.heavyImpact();
         } else if (pinState.error != null) {
+          _resetEnterPinBloc();
           _handleError(pinState);
           HapticFeedback.heavyImpact();
         } else {
@@ -73,8 +77,25 @@ class _SessionPinScreenState extends State<SessionPinScreen>
     }
   }
 
+  EnterPinStateBloc _getOrCreateEnterPinBloc(int maxPinSize) {
+    if (_enterPinBloc == null || _currentMaxPinSize != maxPinSize) {
+      _enterPinBloc?.close();
+      _enterPinBloc = EnterPinStateBloc(maxPinSize);
+      _currentMaxPinSize = maxPinSize;
+    }
+    return _enterPinBloc!;
+  }
+
+  void _resetEnterPinBloc() {
+    if (_enterPinBloc != null && _currentMaxPinSize != null) {
+      _enterPinBloc!.close();
+      _enterPinBloc = EnterPinStateBloc(_currentMaxPinSize!);
+    }
+  }
+
   @override
   void dispose() {
+    _enterPinBloc?.close();
     _pinBlocSubscription?.cancel();
     _pinBloc.close();
     WidgetsBinding.instance.removeObserver(this);
@@ -181,7 +202,7 @@ class _SessionPinScreenState extends State<SessionPinScreen>
                             final maxPinSize = (snapshot.data ?? false)
                                 ? longPinSize
                                 : shortPinSize;
-                            final pinBloc = EnterPinStateBloc(maxPinSize);
+                            final pinBloc = _getOrCreateEnterPinBloc(maxPinSize);
 
                             final enabled =
                                 (blockedFor.data ?? Duration.zero).inSeconds <=

--- a/yivi_core/lib/src/screens/pin/session_pin_screen.dart
+++ b/yivi_core/lib/src/screens/pin/session_pin_screen.dart
@@ -202,7 +202,9 @@ class _SessionPinScreenState extends State<SessionPinScreen>
                             final maxPinSize = (snapshot.data ?? false)
                                 ? longPinSize
                                 : shortPinSize;
-                            final pinBloc = _getOrCreateEnterPinBloc(maxPinSize);
+                            final pinBloc = _getOrCreateEnterPinBloc(
+                              maxPinSize,
+                            );
 
                             final enabled =
                                 (blockedFor.data ?? Duration.zero).inSeconds <=

--- a/yivi_core/lib/src/screens/pin/yivi_pin_screen.dart
+++ b/yivi_core/lib/src/screens/pin/yivi_pin_screen.dart
@@ -1,6 +1,5 @@
 library;
 
-import "dart:async";
 import "dart:math";
 
 import "package:flutter/material.dart";
@@ -178,7 +177,16 @@ class YiviPinScreen extends StatelessWidget {
             },
           ),
         ),
-        Expanded(child: _NumberPad(onEnterNumber: pinBloc.add)),
+        Expanded(
+          child: IgnorePointer(
+            ignoring: !enabled,
+            child: AnimatedOpacity(
+              opacity: enabled ? 1.0 : 0.4,
+              duration: const Duration(milliseconds: 200),
+              child: _NumberPad(onEnterNumber: pinBloc.add),
+            ),
+          ),
+        ),
       ],
     );
   }
@@ -246,7 +254,16 @@ class YiviPinScreen extends StatelessWidget {
             },
           ),
         ),
-        Expanded(child: _NumberPad(onEnterNumber: pinBloc.add)),
+        Expanded(
+          child: IgnorePointer(
+            ignoring: !enabled,
+            child: AnimatedOpacity(
+              opacity: enabled ? 1.0 : 0.4,
+              duration: const Duration(milliseconds: 200),
+              child: _NumberPad(onEnterNumber: pinBloc.add),
+            ),
+          ),
+        ),
         if (maxPinSize != shortPinSize)
           Padding(
             padding: EdgeInsets.only(top: theme.screenPadding),


### PR DESCRIPTION
## Summary
- **Fix dropped digits when typing PIN quickly** — migrated `EnterPinStateBloc` from deprecated `mapEventToState` (async generator with stale state reads) to synchronous `on<Event>` + `emit` pattern (#481)
- **Fix PIN dots clearing and keypad staying active during verification** — lifted `EnterPinStateBloc` to widget state so it survives rebuilds; PIN is only cleared on auth failure/error, not when verification starts (#508)
- **Disable keypad during PIN verification** — wrapped number pad in `IgnorePointer` with `AnimatedOpacity` fade to 40%, giving visual feedback alongside the existing `CircularProgressIndicator`

Closes #481
Closes #508

## Test plan
- [x] Enter 5-digit PIN quickly — all digits should register
- [x] After entering 5 digits, dots should remain filled while PIN is verified
- [x] Keypad should be visually dimmed and unresponsive during verification
- [x] On wrong PIN, dots should clear and keypad should re-enable
- [x] On correct PIN, app proceeds normally
- [x] Verify same behavior on session PIN screen
- [x] Run `flutter test test/secure_pin_test.dart` — all pass