### PR TITLE
fix(yivi_core): cache decoded LogoImage to stop credential flicker

### DIFF
--- a/yivi_core/lib/src/models/schemaless/schemaless_events.dart
+++ b/yivi_core/lib/src/models/schemaless/schemaless_events.dart
@@ -111,9 +111,13 @@ class LogoImage {
 
   LogoImage({required this.base64, this.mimeType});
 
-  Image getImageFromBase64() {
-    return Image.memory(base64Decode(base64));
-  }
+  @JsonKey(includeFromJson: false, includeToJson: false)
+  late final Image _cachedImage = Image.memory(
+    base64Decode(base64),
+    gaplessPlayback: true,
+  );
+
+  Image getImageFromBase64() => _cachedImage;
 
   factory LogoImage.fromJson(Map<String, dynamic> json) =>
       _$LogoImageFromJson(json);


### PR DESCRIPTION
## Summary
- Closes #533 — credential logo icons flickered on every parent rebuild as of 7.14.
- `LogoImage.getImageFromBase64()` returned a fresh `Image.memory(base64Decode(base64))` on each call, so `YiviCredentialCard`'s inline use produced a new `MemoryImage` provider on every rebuild. With `gaplessPlayback` defaulting to `false`, Flutter cleared the old frame before the new one decoded → visible flicker.
- Cache the decoded `Image` in a `late final` field so the same provider is reused across rebuilds, and set `gaplessPlayback: true` as defence-in-depth. `@JsonKey(includeFromJson: false, includeToJson: false)` keeps the cache out of `json_serializable` codegen.

## Notes
- Regression introduced by the card redesign in #529 (commit 0062aa9) which added the inline call sites in `yivi_credential_card.dart`.
- No changes needed to `.g.dart` — the new field is annotated to be skipped by codegen, but re-running `build_runner` is harmless.