### PR TITLE
Add optional biometric unlock for app open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Add optional biometric unlock for opening the app
 
 ## [7.14.0] - 2026-05-13
 ### Changed

--- a/yivi_app/android/app/src/main/AndroidManifest.xml
+++ b/yivi_app/android/app/src/main/AndroidManifest.xml
@@ -80,4 +80,5 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 </manifest>

--- a/yivi_app/android/app/src/main/AndroidManifest.xml
+++ b/yivi_app/android/app/src/main/AndroidManifest.xml
@@ -90,4 +90,5 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.USE_BIOMETRIC" />
 </manifest>

--- a/yivi_app/android/app/src/main/java/foundation/privacybydesign/irmamobile/MainActivity.java
+++ b/yivi_app/android/app/src/main/java/foundation/privacybydesign/irmamobile/MainActivity.java
@@ -12,14 +12,14 @@ import android.content.Intent;
 
 import java.nio.channels.Channel;
 
-import io.flutter.embedding.android.FlutterActivity;
+import io.flutter.embedding.android.FlutterFragmentActivity;
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.android.FlutterSurfaceView;
 import io.flutter.embedding.android.FlutterTextureView;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugins.GeneratedPluginRegistrant;
 
-public class MainActivity extends FlutterActivity {
+public class MainActivity extends FlutterFragmentActivity {
   @Override
   public void configureFlutterEngine(@NonNull FlutterEngine flutterEngine) {
     GeneratedPluginRegistrant.registerWith(flutterEngine);

--- a/yivi_app/integration_test/biometric_unlock_test.dart
+++ b/yivi_app/integration_test/biometric_unlock_test.dart
@@ -101,21 +101,20 @@ void main() {
       expect(find.byKey(const Key("biometric_unlock_toggle")), findsNothing);
     });
 
-    testWidgets(
-      "toggle visible and defaults off when supported",
-      (tester) async {
-        await openSettings(tester);
-        final toggle = find.byKey(const Key("biometric_unlock_toggle"));
-        await tester.scrollUntilVisible(toggle.hitTestable(), 50);
-        expect(switchOf(toggle).value, false);
-        expect(
-          await irmaBinding.repository.preferences
-              .getBiometricUnlockEnabled()
-              .first,
-          false,
-        );
-      },
-    );
+    testWidgets("toggle visible and defaults off when supported", (
+      tester,
+    ) async {
+      await openSettings(tester);
+      final toggle = find.byKey(const Key("biometric_unlock_toggle"));
+      await tester.scrollUntilVisible(toggle.hitTestable(), 50);
+      expect(switchOf(toggle).value, false);
+      expect(
+        await irmaBinding.repository.preferences
+            .getBiometricUnlockEnabled()
+            .first,
+        false,
+      );
+    });
 
     testWidgets("enabling toggle requires a successful biometric prompt", (
       tester,
@@ -307,16 +306,15 @@ void main() {
       );
     });
 
-    testWidgets(
-      "unsupported device skips biometric setup entirely",
-      (tester) async {
-        fakeBiometric.supported = false;
-        await goThroughPinConfirm(tester);
+    testWidgets("unsupported device skips biometric setup entirely", (
+      tester,
+    ) async {
+      fakeBiometric.supported = false;
+      await goThroughPinConfirm(tester);
 
-        expect(find.byType(BiometricSetupScreen), findsNothing);
-        expect(find.byType(ProvideEmailScreen), findsOneWidget);
-      },
-    );
+      expect(find.byType(BiometricSetupScreen), findsNothing);
+      expect(find.byType(ProvideEmailScreen), findsOneWidget);
+    });
   });
 
   // ===========================================================================
@@ -385,31 +383,30 @@ void main() {
       await unlockAndWaitForHome(tester);
     });
 
-    testWidgets(
-      "tapping the fingerprint key retries the biometric prompt",
-      (tester) async {
-        final repo = irmaBinding.repository;
-        await repo.preferences.setBiometricUnlockEnabled(true);
-        repo.lock();
-        // First attempt is cancelled, second succeeds.
-        fakeBiometric.nextResult = const BiometricAuthResult(
-          success: false,
-          cancelled: true,
-        );
+    testWidgets("tapping the fingerprint key retries the biometric prompt", (
+      tester,
+    ) async {
+      final repo = irmaBinding.repository;
+      await repo.preferences.setBiometricUnlockEnabled(true);
+      repo.lock();
+      // First attempt is cancelled, second succeeds.
+      fakeBiometric.nextResult = const BiometricAuthResult(
+        success: false,
+        cancelled: true,
+      );
 
-        await pumpYiviApp(tester, repo);
-        await tester.waitFor(find.byKey(const Key("pin_screen")));
-        await tester.pumpAndSettle();
-        expect(fakeBiometric.authenticateCalls, 1);
+      await pumpYiviApp(tester, repo);
+      await tester.waitFor(find.byKey(const Key("pin_screen")));
+      await tester.pumpAndSettle();
+      expect(fakeBiometric.authenticateCalls, 1);
 
-        // Tap the retry fingerprint key with a successful outcome this time.
-        fakeBiometric.nextResult = const BiometricAuthResult(success: true);
-        await tester.tapAndSettle(find.byIcon(Icons.fingerprint));
+      // Tap the retry fingerprint key with a successful outcome this time.
+      fakeBiometric.nextResult = const BiometricAuthResult(success: true);
+      await tester.tapAndSettle(find.byIcon(Icons.fingerprint));
 
-        await tester.waitFor(find.byType(HomeScreen));
-        expect(fakeBiometric.authenticateCalls, 2);
-        expect(await repo.getLocked().first, false);
-      },
-    );
+      await tester.waitFor(find.byType(HomeScreen));
+      expect(fakeBiometric.authenticateCalls, 2);
+      expect(await repo.getLocked().first, false);
+    });
   });
 }

--- a/yivi_app/integration_test/biometric_unlock_test.dart
+++ b/yivi_app/integration_test/biometric_unlock_test.dart
@@ -1,0 +1,415 @@
+import "package:flutter/cupertino.dart";
+import "package:flutter/material.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:integration_test/integration_test.dart";
+
+import "package:yivi_core/src/models/enrollment_status.dart";
+import "package:yivi_core/src/screens/enrollment/biometric_setup/biometric_setup_screen.dart";
+import "package:yivi_core/src/screens/enrollment/enrollment_screen.dart";
+import "package:yivi_core/src/screens/enrollment/provide_email/provide_email_screen.dart";
+import "package:yivi_core/src/screens/home/home_screen.dart";
+import "package:yivi_core/src/screens/settings/settings_screen.dart";
+import "package:yivi_core/src/util/biometric_auth.dart";
+
+import "helpers/fake_biometric_auth.dart";
+import "helpers/helpers.dart";
+import "irma_binding.dart";
+import "util.dart";
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+  final irmaBinding = IntegrationTestIrmaBinding.ensureInitialized();
+  WidgetController.hitTestWarningShouldBeFatal = true;
+
+  // Default to a fake that reports supported + successful authenticate. Each
+  // test reconfigures the returned fake as needed.
+  late FakeBiometricAuth fakeBiometric;
+
+  setUp(() {
+    fakeBiometric = FakeBiometricAuth.install();
+  });
+  tearDown(FakeBiometricAuth.clearOverride);
+
+  // ===========================================================================
+  // Repository / preferences (no UI)
+  // ===========================================================================
+
+  group("biometric-repository", () {
+    setUp(() => irmaBinding.setUp());
+    tearDown(() => irmaBinding.tearDown());
+
+    testWidgets("unlockWithBiometrics flips locked state", (tester) async {
+      final repo = irmaBinding.repository;
+      repo.lock();
+      expect(await repo.getLocked().first, true);
+
+      repo.unlockWithBiometrics();
+
+      expect(await repo.getLocked().first, false);
+      expect(await repo.getBlockTime().first, isNull);
+    });
+
+    testWidgets("preference defaults to false on a fresh setup", (
+      tester,
+    ) async {
+      final repo = irmaBinding.repository;
+      expect(await repo.preferences.getBiometricUnlockEnabled().first, false);
+      expect(repo.preferences.getBiometricUnlockEnabledSync(), false);
+    });
+
+    testWidgets("preference round-trips through set/get", (tester) async {
+      final repo = irmaBinding.repository;
+      await repo.preferences.setBiometricUnlockEnabled(true);
+      expect(await repo.preferences.getBiometricUnlockEnabled().first, true);
+      expect(repo.preferences.getBiometricUnlockEnabledSync(), true);
+
+      await repo.preferences.setBiometricUnlockEnabled(false);
+      expect(await repo.preferences.getBiometricUnlockEnabled().first, false);
+    });
+  });
+
+  // ===========================================================================
+  // Settings screen toggle
+  // ===========================================================================
+
+  group("biometric-settings", () {
+    setUp(() => irmaBinding.setUp());
+    tearDown(() => irmaBinding.tearDown());
+
+    Future<void> openSettings(WidgetTester tester) async {
+      await pumpAndUnlockApp(tester, irmaBinding.repository);
+      await tester.tapAndSettle(find.byKey(const Key("nav_button_more")));
+      await tester.tapAndSettle(
+        find.byKey(const Key("open_settings_screen_button")),
+      );
+      expect(find.byType(SettingsScreen), findsOneWidget);
+    }
+
+    CupertinoSwitch switchOf(Finder toggleFinder) {
+      final inner = find.descendant(
+        of: toggleFinder,
+        matching: find.byType(CupertinoSwitch),
+      );
+      return inner.evaluate().single.widget as CupertinoSwitch;
+    }
+
+    testWidgets("toggle is hidden when device reports unsupported", (
+      tester,
+    ) async {
+      fakeBiometric.supported = false;
+      await openSettings(tester);
+      expect(find.byKey(const Key("biometric_unlock_toggle")), findsNothing);
+    });
+
+    testWidgets(
+      "toggle visible and defaults off when supported",
+      (tester) async {
+        await openSettings(tester);
+        final toggle = find.byKey(const Key("biometric_unlock_toggle"));
+        await tester.scrollUntilVisible(toggle.hitTestable(), 50);
+        expect(switchOf(toggle).value, false);
+        expect(
+          await irmaBinding.repository.preferences
+              .getBiometricUnlockEnabled()
+              .first,
+          false,
+        );
+      },
+    );
+
+    testWidgets("enabling toggle requires a successful biometric prompt", (
+      tester,
+    ) async {
+      await openSettings(tester);
+      final toggle = find.byKey(const Key("biometric_unlock_toggle"));
+      await tester.scrollUntilVisible(toggle.hitTestable(), 50);
+
+      expect(fakeBiometric.authenticateCalls, 0);
+      await tester.tapAndSettle(toggle);
+
+      expect(fakeBiometric.authenticateCalls, 1);
+      expect(switchOf(toggle).value, true);
+      expect(
+        await irmaBinding.repository.preferences
+            .getBiometricUnlockEnabled()
+            .first,
+        true,
+      );
+    });
+
+    testWidgets("cancelled biometric prompt leaves the toggle off", (
+      tester,
+    ) async {
+      fakeBiometric.nextResult = const BiometricAuthResult(
+        success: false,
+        cancelled: true,
+      );
+      await openSettings(tester);
+      final toggle = find.byKey(const Key("biometric_unlock_toggle"));
+      await tester.scrollUntilVisible(toggle.hitTestable(), 50);
+
+      await tester.tapAndSettle(toggle);
+
+      expect(fakeBiometric.authenticateCalls, 1);
+      expect(switchOf(toggle).value, false);
+      expect(
+        await irmaBinding.repository.preferences
+            .getBiometricUnlockEnabled()
+            .first,
+        false,
+      );
+    });
+
+    testWidgets("disabling toggle does NOT prompt biometric", (tester) async {
+      await irmaBinding.repository.preferences.setBiometricUnlockEnabled(true);
+      await openSettings(tester);
+      final toggle = find.byKey(const Key("biometric_unlock_toggle"));
+      await tester.scrollUntilVisible(toggle.hitTestable(), 50);
+      expect(switchOf(toggle).value, true);
+
+      await tester.tapAndSettle(toggle);
+
+      // canAuthenticate is consulted on screen mount; disabling itself must
+      // not trigger another authenticate prompt.
+      expect(fakeBiometric.authenticateCalls, 0);
+      expect(switchOf(toggle).value, false);
+      expect(
+        await irmaBinding.repository.preferences
+            .getBiometricUnlockEnabled()
+            .first,
+        false,
+      );
+    });
+
+    testWidgets("preferences.clearAll resets biometric unlock to false", (
+      tester,
+    ) async {
+      final repo = irmaBinding.repository;
+      await repo.preferences.setBiometricUnlockEnabled(true);
+      expect(await repo.preferences.getBiometricUnlockEnabled().first, true);
+
+      await repo.preferences.clearAll();
+
+      expect(await repo.preferences.getBiometricUnlockEnabled().first, false);
+    });
+  });
+
+  // ===========================================================================
+  // Enrollment biometric setup step
+  // ===========================================================================
+
+  group("biometric-enrollment", () {
+    setUp(
+      () => irmaBinding.setUp(enrollmentStatus: EnrollmentStatus.unenrolled),
+    );
+    tearDown(() => irmaBinding.tearDown());
+
+    Future<void> goThroughPinConfirm(WidgetTester tester) async {
+      await pumpYiviApp(tester, irmaBinding.repository);
+      expect(find.byType(EnrollmentScreen), findsOneWidget);
+
+      // Introduction (3 next presses).
+      final nextButtonFinder = find.byKey(const Key("enrollment_next_button"));
+      for (var i = 0; i < 3; i++) {
+        await tester.tap(nextButtonFinder);
+        await tester.pump(const Duration(milliseconds: 500));
+      }
+      // Accept terms.
+      final checkBoxFinder = find.byKey(const Key("accept_terms_checkbox"));
+      await tester.scrollUntilVisible(checkBoxFinder.hitTestable(), 50);
+      await tester.tapAndSettle(checkBoxFinder);
+      await tester.tapAndSettle(nextButtonFinder);
+
+      // Choose + confirm PIN.
+      const pin = "12345";
+      await enterPin(tester, pin);
+      await tester.tapAndSettle(find.text("Next"));
+      await enterPin(tester, pin);
+      await tester.pumpAndSettle();
+    }
+
+    testWidgets("setup screen appears after pin-confirm on supported device", (
+      tester,
+    ) async {
+      await goThroughPinConfirm(tester);
+      expect(find.byType(BiometricSetupScreen), findsOneWidget);
+      // The provide-email screen has NOT been shown yet.
+      expect(find.byType(ProvideEmailScreen), findsNothing);
+      expect(
+        await irmaBinding.repository.preferences
+            .getBiometricUnlockEnabled()
+            .first,
+        false,
+      );
+    });
+
+    testWidgets("skip leaves preference disabled and continues to email", (
+      tester,
+    ) async {
+      await goThroughPinConfirm(tester);
+      expect(find.byType(BiometricSetupScreen), findsOneWidget);
+
+      // The secondary button is the skip action.
+      await tester.tapAndSettle(find.byKey(const Key("bottom_bar_secondary")));
+
+      expect(find.byType(BiometricSetupScreen), findsNothing);
+      expect(find.byType(ProvideEmailScreen), findsOneWidget);
+      expect(
+        await irmaBinding.repository.preferences
+            .getBiometricUnlockEnabled()
+            .first,
+        false,
+      );
+      expect(fakeBiometric.authenticateCalls, 0);
+    });
+
+    testWidgets("enable + successful prompt sets the preference", (
+      tester,
+    ) async {
+      await goThroughPinConfirm(tester);
+      expect(find.byType(BiometricSetupScreen), findsOneWidget);
+
+      await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
+
+      expect(fakeBiometric.authenticateCalls, 1);
+      expect(find.byType(BiometricSetupScreen), findsNothing);
+      expect(find.byType(ProvideEmailScreen), findsOneWidget);
+      expect(
+        await irmaBinding.repository.preferences
+            .getBiometricUnlockEnabled()
+            .first,
+        true,
+      );
+    });
+
+    testWidgets("enable + cancelled prompt keeps user on setup screen", (
+      tester,
+    ) async {
+      fakeBiometric.nextResult = const BiometricAuthResult(
+        success: false,
+        cancelled: true,
+      );
+      await goThroughPinConfirm(tester);
+      expect(find.byType(BiometricSetupScreen), findsOneWidget);
+
+      await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
+
+      expect(fakeBiometric.authenticateCalls, 1);
+      // The bloc only advances on success; the user remains on the biometric
+      // setup screen so they can retry or skip.
+      expect(find.byType(BiometricSetupScreen), findsOneWidget);
+      expect(find.byType(ProvideEmailScreen), findsNothing);
+      expect(
+        await irmaBinding.repository.preferences
+            .getBiometricUnlockEnabled()
+            .first,
+        false,
+      );
+    });
+
+    testWidgets(
+      "unsupported device skips biometric setup entirely",
+      (tester) async {
+        fakeBiometric.supported = false;
+        await goThroughPinConfirm(tester);
+
+        expect(find.byType(BiometricSetupScreen), findsNothing);
+        expect(find.byType(ProvideEmailScreen), findsOneWidget);
+      },
+    );
+  });
+
+  // ===========================================================================
+  // App-open /pin screen biometric bypass
+  // ===========================================================================
+
+  group("biometric-pin-screen", () {
+    setUp(() => irmaBinding.setUp());
+    tearDown(() => irmaBinding.tearDown());
+
+    testWidgets("preference disabled: no biometric prompt on app open", (
+      tester,
+    ) async {
+      // Default preference is false.
+      await pumpYiviApp(tester, irmaBinding.repository);
+
+      // Wait for the pin screen to be present.
+      await tester.waitFor(find.byKey(const Key("pin_screen")));
+
+      // Pin screen short-circuits before consulting the biometric APIs when
+      // the preference is off — neither canAuthenticate nor authenticate fire.
+      expect(fakeBiometric.authenticateCalls, 0);
+
+      // Manual PIN entry still works.
+      await unlockAndWaitForHome(tester);
+    });
+
+    testWidgets(
+      "preference enabled: biometric prompt fires and unlocks without keyshare",
+      (tester) async {
+        final repo = irmaBinding.repository;
+        await repo.preferences.setBiometricUnlockEnabled(true);
+        // Force the app into the locked state so /pin is presented on pump.
+        repo.lock();
+
+        await pumpYiviApp(tester, repo);
+
+        // Wait for the biometric path to settle (canAuthenticate -> authenticate
+        // -> unlockWithBiometrics -> onAuthenticated -> home).
+        await tester.waitFor(find.byType(HomeScreen));
+        expect(fakeBiometric.authenticateCalls, 1);
+        expect(await repo.getLocked().first, false);
+      },
+    );
+
+    testWidgets("cancelled biometric falls back to the manual PIN keypad", (
+      tester,
+    ) async {
+      final repo = irmaBinding.repository;
+      await repo.preferences.setBiometricUnlockEnabled(true);
+      repo.lock();
+      fakeBiometric.nextResult = const BiometricAuthResult(
+        success: false,
+        cancelled: true,
+      );
+
+      await pumpYiviApp(tester, repo);
+      await tester.waitFor(find.byKey(const Key("pin_screen")));
+      await tester.pumpAndSettle();
+
+      expect(fakeBiometric.authenticateCalls, 1);
+      expect(await repo.getLocked().first, true);
+
+      // Number pad is interactive; the fingerprint retry icon is visible.
+      expect(find.byIcon(Icons.fingerprint), findsOneWidget);
+      await unlockAndWaitForHome(tester);
+    });
+
+    testWidgets(
+      "tapping the fingerprint key retries the biometric prompt",
+      (tester) async {
+        final repo = irmaBinding.repository;
+        await repo.preferences.setBiometricUnlockEnabled(true);
+        repo.lock();
+        // First attempt is cancelled, second succeeds.
+        fakeBiometric.nextResult = const BiometricAuthResult(
+          success: false,
+          cancelled: true,
+        );
+
+        await pumpYiviApp(tester, repo);
+        await tester.waitFor(find.byKey(const Key("pin_screen")));
+        await tester.pumpAndSettle();
+        expect(fakeBiometric.authenticateCalls, 1);
+
+        // Tap the retry fingerprint key with a successful outcome this time.
+        fakeBiometric.nextResult = const BiometricAuthResult(success: true);
+        await tester.tapAndSettle(find.byIcon(Icons.fingerprint));
+
+        await tester.waitFor(find.byType(HomeScreen));
+        expect(fakeBiometric.authenticateCalls, 2);
+        expect(await repo.getLocked().first, false);
+      },
+    );
+  });
+}

--- a/yivi_app/integration_test/helpers/fake_biometric_auth.dart
+++ b/yivi_app/integration_test/helpers/fake_biometric_auth.dart
@@ -1,0 +1,55 @@
+import "package:yivi_core/src/util/biometric_auth.dart";
+
+/// Fake [BiometricAuth] for integration tests.
+///
+/// Lets tests script `canAuthenticate()` (does the device claim support?) and
+/// `authenticate()` (what does the OS prompt return?) without ever touching
+/// the platform `local_auth` channel.
+///
+/// Install it via [BiometricAuth.overrideFactory] in `setUp` and clear it in
+/// `tearDown`. See [install] / [clearOverride].
+class FakeBiometricAuth extends BiometricAuth {
+  bool supported;
+  BiometricAuthResult nextResult;
+  int authenticateCalls = 0;
+  int canAuthenticateCalls = 0;
+
+  FakeBiometricAuth({
+    this.supported = true,
+    BiometricAuthResult? result,
+  }) : nextResult = result ?? const BiometricAuthResult(success: true),
+       super.forTesting();
+
+  /// Install this fake as the global `BiometricAuth()` factory override.
+  /// Returns the fake so tests can reconfigure it mid-test.
+  static FakeBiometricAuth install({
+    bool supported = true,
+    BiometricAuthResult? result,
+  }) {
+    final fake = FakeBiometricAuth(supported: supported, result: result);
+    BiometricAuth.overrideFactory = () => fake;
+    return fake;
+  }
+
+  static void clearOverride() {
+    BiometricAuth.overrideFactory = null;
+  }
+
+  @override
+  Future<bool> canAuthenticate() async {
+    canAuthenticateCalls++;
+    return supported;
+  }
+
+  @override
+  Future<BiometricAuthResult> authenticate({
+    required String reason,
+    required String androidSignInTitle,
+    required String androidCancelButton,
+    required String iosCancelButton,
+    required String iosLockoutMessage,
+  }) async {
+    authenticateCalls++;
+    return nextResult;
+  }
+}

--- a/yivi_app/integration_test/helpers/fake_biometric_auth.dart
+++ b/yivi_app/integration_test/helpers/fake_biometric_auth.dart
@@ -14,11 +14,9 @@ class FakeBiometricAuth extends BiometricAuth {
   int authenticateCalls = 0;
   int canAuthenticateCalls = 0;
 
-  FakeBiometricAuth({
-    this.supported = true,
-    BiometricAuthResult? result,
-  }) : nextResult = result ?? const BiometricAuthResult(success: true),
-       super.forTesting();
+  FakeBiometricAuth({this.supported = true, BiometricAuthResult? result})
+    : nextResult = result ?? const BiometricAuthResult(success: true),
+      super.forTesting();
 
   /// Install this fake as the global `BiometricAuth()` factory override.
   /// Returns the fake so tests can reconfigure it mid-test.

--- a/yivi_app/integration_test/test_all.dart
+++ b/yivi_app/integration_test/test_all.dart
@@ -1,4 +1,5 @@
 import "activity_test.dart" as activity_test;
+import "biometric_unlock_test.dart" as biometric_unlock_test;
 import "data_search_test.dart" as search_test;
 import "disclose_sdjwt_over_openid4vp_test.dart" as openid4vp_test;
 import "disclosure_session/disclosure_session_test_all.dart"
@@ -47,6 +48,7 @@ void main() {
   idle_lock_test.main();
   login_test.main();
   settings_test.main();
+  biometric_unlock_test.main();
   issuance_test.main();
   more_tab_test.main();
   activity_test.main();

--- a/yivi_app/integration_test/test_all.dart
+++ b/yivi_app/integration_test/test_all.dart
@@ -1,4 +1,5 @@
 import "activity_test.dart" as activity_test;
+import "biometric_unlock_test.dart" as biometric_unlock_test;
 import "data_search_test.dart" as search_test;
 import "disclose_sdjwt_over_openid4vp_test.dart" as openid4vp_test;
 import "disclosure_session/disclosure_session_test_all.dart"
@@ -45,6 +46,7 @@ void main() {
   enroll_test.main();
   login_test.main();
   settings_test.main();
+  biometric_unlock_test.main();
   issuance_test.main();
   more_tab_test.main();
   activity_test.main();

--- a/yivi_app/ios/Runner/Info.plist
+++ b/yivi_app/ios/Runner/Info.plist
@@ -62,6 +62,8 @@
     </array>
     <key>NFCReaderUsageDescription</key>
     <string>Reading passport</string>
+    <key>NSFaceIDUsageDescription</key>
+    <string>Use Face ID to open Yivi.</string>
     <key>CFBundleVersion</key>
     <string>$(FLUTTER_BUILD_NUMBER)</string>
     <key>LSRequiresIPhoneOS</key>

--- a/yivi_app/ios/Runner/Info.plist
+++ b/yivi_app/ios/Runner/Info.plist
@@ -63,6 +63,8 @@
     </array>
     <key>NFCReaderUsageDescription</key>
     <string>Reading passport</string>
+    <key>NSFaceIDUsageDescription</key>
+    <string>Use Face ID to open Yivi.</string>
     <key>CFBundleVersion</key>
     <string>$(FLUTTER_BUILD_NUMBER)</string>
     <key>LSRequiresIPhoneOS</key>

--- a/yivi_app/pubspec.lock
+++ b/yivi_app/pubspec.lock
@@ -493,6 +493,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  local_auth:
+    dependency: transitive
+    description:
+      name: local_auth
+      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  local_auth_android:
+    dependency: transitive
+    description:
+      name: local_auth_android
+      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.56"
+  local_auth_darwin:
+    dependency: transitive
+    description:
+      name: local_auth_darwin
+      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.1"
+  local_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: local_auth_platform_interface
+      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  local_auth_windows:
+    dependency: transitive
+    description:
+      name: local_auth_windows
+      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
   logger:
     dependency: transitive
     description:

--- a/yivi_app/pubspec.lock
+++ b/yivi_app/pubspec.lock
@@ -525,6 +525,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  local_auth:
+    dependency: transitive
+    description:
+      name: local_auth
+      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  local_auth_android:
+    dependency: transitive
+    description:
+      name: local_auth_android
+      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.56"
+  local_auth_darwin:
+    dependency: transitive
+    description:
+      name: local_auth_darwin
+      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.1"
+  local_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: local_auth_platform_interface
+      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  local_auth_windows:
+    dependency: transitive
+    description:
+      name: local_auth_windows
+      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
   logger:
     dependency: transitive
     description:

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -276,13 +276,6 @@
     "confirm_pin": {
       "instruction": "Geben Sie Ihre PIN erneut ein"
     },
-    "biometric": {
-      "title": "Yivi mit Biometrie öffnen",
-      "explanation": "Sie können Face ID, Touch ID oder Ihren Fingerabdruck verwenden, um die Yivi-App zu öffnen, anstatt jedes Mal Ihre PIN einzugeben. Beim Teilen oder Empfangen von Nachweisen werden Sie weiterhin nach Ihrer PIN gefragt.",
-      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät. Sie werden nicht an Yivi, nicht an Aussteller und nicht an die Parteien weitergegeben, mit denen Sie Nachweise teilen. Biometrie wird ausschließlich verwendet, um die Yivi-App auf Ihrem Telefon zu entsperren.",
-      "enable": "Biometrie verwenden",
-      "skip": "Nicht jetzt"
-    },
     "email": {
       "provide": {
         "title": "E-Mail-Adresse hinzufügen",
@@ -328,6 +321,13 @@
     "submit": {
       "title": "Anmeldung",
       "progress_enrollment": "Willkommen! Bitte warten Sie einen Moment, wir melden Sie an."
+    },
+    "biometric": {
+      "title": "Yivi mit Biometrie öffnen",
+      "explanation": "Verwenden Sie Face ID, Touch ID oder Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird beim Teilen oder Empfangen weiterhin benötigt.",
+      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät und werden nie an Yivi, Aussteller oder Parteien weitergegeben.",
+      "enable": "Biometrie verwenden",
+      "skip": "Nicht jetzt"
     }
   },
   "error": {
@@ -563,8 +563,8 @@
     "button_block": "Yivi sperren",
     "biometric": {
       "reason": "Yivi entsperren",
-      "android_title": "Scannen Sie Ihre Biometrie, um Yivi zu entsperren",
-      "lockout": "Biometrische Authentifizierung ist nicht verfügbar. Geben Sie stattdessen Ihre PIN ein.",
+      "android_title": "Biometrie scannen, um Yivi zu entsperren",
+      "lockout": "Biometrie nicht verfügbar. Geben Sie Ihre PIN ein.",
       "retry": "Mit Biometrie entsperren"
     }
   },
@@ -685,9 +685,6 @@
     "report_errors_explanation": "Durch die Aktivierung der Fehler- und App-Status-Berichterstattung helfen Sie uns, die Benutzererfahrung zu verbessern.",
     "enable_screenshots": "Screenshots aktivieren",
     "enable_screenshots_explanation": "Wenn aktiviert, wird die App im App-Umschalter nicht unscharf dargestellt.",
-    "biometric_unlock": "Mit Biometrie entsperren",
-    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Ihren Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird weiterhin benötigt, wenn Sie Nachweise teilen oder erhalten.",
-    "biometric_unlock_prompt": "Bestätigen Sie, um die biometrische Entsperrung zu aktivieren",
     "developer_mode": "Entwicklermodus",
     "other": "Sonstiges",
     "language": "Sprache",
@@ -699,7 +696,10 @@
       "explanation": "Wenn Sie fortfahren, werden alle Daten aus Ihrer Yivi-App gelöscht. Wenn Sie Yivi weiter nutzen möchten, müssen Sie die Daten neu laden.",
       "confirm": "Ja, alles löschen",
       "deny": "Abbrechen"
-    }
+    },
+    "biometric_unlock": "Mit Biometrie entsperren",
+    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Fingerabdruck, um Yivi zu öffnen.",
+    "biometric_unlock_prompt": "Zum Aktivieren bestätigen"
   },
   "ui": {
     "loading": "Laden…",

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -278,6 +278,13 @@
     "confirm_pin": {
       "instruction": "Geben Sie Ihre PIN erneut ein"
     },
+    "biometric": {
+      "title": "Yivi mit Biometrie öffnen",
+      "explanation": "Sie können Face ID, Touch ID oder Ihren Fingerabdruck verwenden, um die Yivi-App zu öffnen, anstatt jedes Mal Ihre PIN einzugeben. Beim Teilen oder Empfangen von Nachweisen werden Sie weiterhin nach Ihrer PIN gefragt.",
+      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät. Sie werden nicht an Yivi, nicht an Aussteller und nicht an die Parteien weitergegeben, mit denen Sie Nachweise teilen. Biometrie wird ausschließlich verwendet, um die Yivi-App auf Ihrem Telefon zu entsperren.",
+      "enable": "Biometrie verwenden",
+      "skip": "Nicht jetzt"
+    },
     "email": {
       "provide": {
         "title": "E-Mail-Adresse hinzufügen",
@@ -554,7 +561,13 @@
   "pin": {
     "subtitle": "Geben Sie Ihre PIN ein",
     "button_forgot": "PIN vergessen",
-    "button_block": "Yivi sperren"
+    "button_block": "Yivi sperren",
+    "biometric": {
+      "reason": "Yivi entsperren",
+      "android_title": "Scannen Sie Ihre Biometrie, um Yivi zu entsperren",
+      "lockout": "Biometrische Authentifizierung ist nicht verfügbar. Geben Sie stattdessen Ihre PIN ein.",
+      "retry": "Mit Biometrie entsperren"
+    }
   },
   "pin_accessibility": {
     "show_pin": "PIN anzeigen",
@@ -673,6 +686,9 @@
     "report_errors_explanation": "Durch die Aktivierung der Fehler- und App-Status-Berichterstattung helfen Sie uns, die Benutzererfahrung zu verbessern.",
     "enable_screenshots": "Screenshots aktivieren",
     "enable_screenshots_explanation": "Wenn aktiviert, wird die App im App-Umschalter nicht unscharf dargestellt.",
+    "biometric_unlock": "Mit Biometrie entsperren",
+    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Ihren Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird weiterhin benötigt, wenn Sie Nachweise teilen oder erhalten.",
+    "biometric_unlock_prompt": "Bestätigen Sie, um die biometrische Entsperrung zu aktivieren",
     "developer_mode": "Entwicklermodus",
     "other": "Sonstiges",
     "language": "Sprache",

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -326,8 +326,8 @@
     },
     "biometric": {
       "title": "Yivi mit Biometrie öffnen",
-      "explanation": "Verwenden Sie Face ID, Touch ID oder Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird beim Teilen oder Empfangen weiterhin benötigt.",
-      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät und werden nie an Yivi, Aussteller oder Parteien weitergegeben.",
+      "explanation": "Sie können Face ID, Touch ID oder Ihren Fingerabdruck verwenden, um die Yivi-App zu öffnen, anstatt jedes Mal Ihre PIN einzugeben. Beim Teilen oder Empfangen von Nachweisen werden Sie weiterhin nach Ihrer PIN gefragt.",
+      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät. Sie werden nicht an Yivi, nicht an Aussteller und nicht an die Parteien weitergegeben, mit denen Sie Nachweise teilen. Biometrie wird ausschließlich verwendet, um die Yivi-App auf Ihrem Telefon zu entsperren.",
       "enable": "Biometrie verwenden",
       "skip": "Nicht jetzt"
     }
@@ -564,8 +564,8 @@
     "button_block": "Yivi sperren",
     "biometric": {
       "reason": "Yivi entsperren",
-      "android_title": "Biometrie scannen, um Yivi zu entsperren",
-      "lockout": "Biometrie nicht verfügbar. Geben Sie Ihre PIN ein.",
+      "android_title": "Scannen Sie Ihre Biometrie, um Yivi zu entsperren",
+      "lockout": "Biometrische Authentifizierung ist nicht verfügbar. Geben Sie stattdessen Ihre PIN ein.",
       "retry": "Mit Biometrie entsperren"
     }
   },
@@ -699,8 +699,8 @@
       "deny": "Abbrechen"
     },
     "biometric_unlock": "Mit Biometrie entsperren",
-    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Fingerabdruck, um Yivi zu öffnen.",
-    "biometric_unlock_prompt": "Zum Aktivieren bestätigen"
+    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Ihren Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird weiterhin benötigt, wenn Sie Nachweise teilen oder erhalten.",
+    "biometric_unlock_prompt": "Bestätigen Sie, um die biometrische Entsperrung zu aktivieren"
   },
   "ui": {
     "loading": "Laden…",

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -278,13 +278,6 @@
     "confirm_pin": {
       "instruction": "Geben Sie Ihre PIN erneut ein"
     },
-    "biometric": {
-      "title": "Yivi mit Biometrie öffnen",
-      "explanation": "Sie können Face ID, Touch ID oder Ihren Fingerabdruck verwenden, um die Yivi-App zu öffnen, anstatt jedes Mal Ihre PIN einzugeben. Beim Teilen oder Empfangen von Nachweisen werden Sie weiterhin nach Ihrer PIN gefragt.",
-      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät. Sie werden nicht an Yivi, nicht an Aussteller und nicht an die Parteien weitergegeben, mit denen Sie Nachweise teilen. Biometrie wird ausschließlich verwendet, um die Yivi-App auf Ihrem Telefon zu entsperren.",
-      "enable": "Biometrie verwenden",
-      "skip": "Nicht jetzt"
-    },
     "email": {
       "provide": {
         "title": "E-Mail-Adresse hinzufügen",
@@ -330,6 +323,13 @@
     "submit": {
       "title": "Anmeldung",
       "progress_enrollment": "Willkommen! Bitte warten Sie einen Moment, wir melden Sie an."
+    },
+    "biometric": {
+      "title": "Yivi mit Biometrie öffnen",
+      "explanation": "Verwenden Sie Face ID, Touch ID oder Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird beim Teilen oder Empfangen weiterhin benötigt.",
+      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät und werden nie an Yivi, Aussteller oder Parteien weitergegeben.",
+      "enable": "Biometrie verwenden",
+      "skip": "Nicht jetzt"
     }
   },
   "error": {
@@ -564,8 +564,8 @@
     "button_block": "Yivi sperren",
     "biometric": {
       "reason": "Yivi entsperren",
-      "android_title": "Scannen Sie Ihre Biometrie, um Yivi zu entsperren",
-      "lockout": "Biometrische Authentifizierung ist nicht verfügbar. Geben Sie stattdessen Ihre PIN ein.",
+      "android_title": "Biometrie scannen, um Yivi zu entsperren",
+      "lockout": "Biometrie nicht verfügbar. Geben Sie Ihre PIN ein.",
       "retry": "Mit Biometrie entsperren"
     }
   },
@@ -686,9 +686,6 @@
     "report_errors_explanation": "Durch die Aktivierung der Fehler- und App-Status-Berichterstattung helfen Sie uns, die Benutzererfahrung zu verbessern.",
     "enable_screenshots": "Screenshots aktivieren",
     "enable_screenshots_explanation": "Wenn aktiviert, wird die App im App-Umschalter nicht unscharf dargestellt.",
-    "biometric_unlock": "Mit Biometrie entsperren",
-    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Ihren Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird weiterhin benötigt, wenn Sie Nachweise teilen oder erhalten.",
-    "biometric_unlock_prompt": "Bestätigen Sie, um die biometrische Entsperrung zu aktivieren",
     "developer_mode": "Entwicklermodus",
     "other": "Sonstiges",
     "language": "Sprache",
@@ -700,7 +697,10 @@
       "explanation": "Wenn Sie fortfahren, werden alle Daten aus Ihrer Yivi-App gelöscht. Wenn Sie Yivi weiter nutzen möchten, müssen Sie die Daten neu laden.",
       "confirm": "Ja, alles löschen",
       "deny": "Abbrechen"
-    }
+    },
+    "biometric_unlock": "Mit Biometrie entsperren",
+    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Fingerabdruck, um Yivi zu öffnen.",
+    "biometric_unlock_prompt": "Zum Aktivieren bestätigen"
   },
   "ui": {
     "loading": "Laden…",

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -276,6 +276,13 @@
     "confirm_pin": {
       "instruction": "Geben Sie Ihre PIN erneut ein"
     },
+    "biometric": {
+      "title": "Yivi mit Biometrie öffnen",
+      "explanation": "Sie können Face ID, Touch ID oder Ihren Fingerabdruck verwenden, um die Yivi-App zu öffnen, anstatt jedes Mal Ihre PIN einzugeben. Beim Teilen oder Empfangen von Nachweisen werden Sie weiterhin nach Ihrer PIN gefragt.",
+      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät. Sie werden nicht an Yivi, nicht an Aussteller und nicht an die Parteien weitergegeben, mit denen Sie Nachweise teilen. Biometrie wird ausschließlich verwendet, um die Yivi-App auf Ihrem Telefon zu entsperren.",
+      "enable": "Biometrie verwenden",
+      "skip": "Nicht jetzt"
+    },
     "email": {
       "provide": {
         "title": "E-Mail-Adresse hinzufügen",
@@ -553,7 +560,13 @@
   "pin": {
     "subtitle": "Geben Sie Ihre PIN ein",
     "button_forgot": "PIN vergessen",
-    "button_block": "Yivi sperren"
+    "button_block": "Yivi sperren",
+    "biometric": {
+      "reason": "Yivi entsperren",
+      "android_title": "Scannen Sie Ihre Biometrie, um Yivi zu entsperren",
+      "lockout": "Biometrische Authentifizierung ist nicht verfügbar. Geben Sie stattdessen Ihre PIN ein.",
+      "retry": "Mit Biometrie entsperren"
+    }
   },
   "pin_accessibility": {
     "show_pin": "PIN anzeigen",
@@ -672,6 +685,9 @@
     "report_errors_explanation": "Durch die Aktivierung der Fehler- und App-Status-Berichterstattung helfen Sie uns, die Benutzererfahrung zu verbessern.",
     "enable_screenshots": "Screenshots aktivieren",
     "enable_screenshots_explanation": "Wenn aktiviert, wird die App im App-Umschalter nicht unscharf dargestellt.",
+    "biometric_unlock": "Mit Biometrie entsperren",
+    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Ihren Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird weiterhin benötigt, wenn Sie Nachweise teilen oder erhalten.",
+    "biometric_unlock_prompt": "Bestätigen Sie, um die biometrische Entsperrung zu aktivieren",
     "developer_mode": "Entwicklermodus",
     "other": "Sonstiges",
     "language": "Sprache",

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -324,8 +324,8 @@
     },
     "biometric": {
       "title": "Yivi mit Biometrie öffnen",
-      "explanation": "Verwenden Sie Face ID, Touch ID oder Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird beim Teilen oder Empfangen weiterhin benötigt.",
-      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät und werden nie an Yivi, Aussteller oder Parteien weitergegeben.",
+      "explanation": "Sie können Face ID, Touch ID oder Ihren Fingerabdruck verwenden, um die Yivi-App zu öffnen, anstatt jedes Mal Ihre PIN einzugeben. Beim Teilen oder Empfangen von Nachweisen werden Sie weiterhin nach Ihrer PIN gefragt.",
+      "privacy": "Ihre biometrischen Daten bleiben auf diesem Gerät. Sie werden nicht an Yivi, nicht an Aussteller und nicht an die Parteien weitergegeben, mit denen Sie Nachweise teilen. Biometrie wird ausschließlich verwendet, um die Yivi-App auf Ihrem Telefon zu entsperren.",
       "enable": "Biometrie verwenden",
       "skip": "Nicht jetzt"
     }
@@ -563,8 +563,8 @@
     "button_block": "Yivi sperren",
     "biometric": {
       "reason": "Yivi entsperren",
-      "android_title": "Biometrie scannen, um Yivi zu entsperren",
-      "lockout": "Biometrie nicht verfügbar. Geben Sie Ihre PIN ein.",
+      "android_title": "Scannen Sie Ihre Biometrie, um Yivi zu entsperren",
+      "lockout": "Biometrische Authentifizierung ist nicht verfügbar. Geben Sie stattdessen Ihre PIN ein.",
       "retry": "Mit Biometrie entsperren"
     }
   },
@@ -698,8 +698,8 @@
       "deny": "Abbrechen"
     },
     "biometric_unlock": "Mit Biometrie entsperren",
-    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Fingerabdruck, um Yivi zu öffnen.",
-    "biometric_unlock_prompt": "Zum Aktivieren bestätigen"
+    "biometric_unlock_explanation": "Verwenden Sie Face ID, Touch ID oder Ihren Fingerabdruck, um Yivi zu öffnen. Ihre PIN wird weiterhin benötigt, wenn Sie Nachweise teilen oder erhalten.",
+    "biometric_unlock_prompt": "Bestätigen Sie, um die biometrische Entsperrung zu aktivieren"
   },
   "ui": {
     "loading": "Laden…",

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -278,13 +278,6 @@
     "confirm_pin": {
       "instruction": "Enter your PIN again"
     },
-    "biometric": {
-      "title": "Open Yivi with your biometrics",
-      "explanation": "You can use Face ID, Touch ID or your fingerprint to open the Yivi app instead of typing your PIN every time. You will still be asked for your PIN when you share or receive credentials.",
-      "privacy": "Your biometric information stays on this device. It is never shared with Yivi, with issuers, or with the parties you share credentials with. Biometrics are only used to unlock the Yivi app on your phone.",
-      "enable": "Use biometrics",
-      "skip": "Not now"
-    },
     "email": {
       "provide": {
         "title": "Add e-mail address",
@@ -330,6 +323,13 @@
     "submit": {
       "title": "Logging in",
       "progress_enrollment": "Welcome! Please wait a moment, we're signing you up."
+    },
+    "biometric": {
+      "title": "Open Yivi with biometrics",
+      "explanation": "Use Face ID, Touch ID or fingerprint to open Yivi. Your PIN is still required to share or receive credentials.",
+      "privacy": "Your biometrics stay on this device and are never shared with Yivi, issuers, or parties you share credentials with.",
+      "enable": "Use biometrics",
+      "skip": "Not now"
     }
   },
   "error": {
@@ -563,9 +563,9 @@
     "button_forgot": "I forgot my PIN",
     "button_block": "Block Yivi",
     "biometric": {
-      "reason": "Unlock Yivi",
+      "reason": "Open Yivi",
       "android_title": "Scan your biometrics to unlock Yivi",
-      "lockout": "Biometric authentication is unavailable. Enter your PIN instead.",
+      "lockout": "Biometric authentication unavailable. Enter your PIN.",
       "retry": "Unlock with biometrics"
     }
   },
@@ -686,9 +686,6 @@
     "report_errors_explanation": "By enabling error and app status reporting you are helping us improve the user experience.",
     "enable_screenshots": "Enable screenshots",
     "enable_screenshots_explanation": "When enabled, the app will not be blurred in the app switcher.",
-    "biometric_unlock": "Unlock with biometrics",
-    "biometric_unlock_explanation": "Use Face ID, Touch ID or your fingerprint to open Yivi. Your PIN is still required when sharing or receiving credentials.",
-    "biometric_unlock_prompt": "Confirm to enable biometric unlock",
     "developer_mode": "Developer mode",
     "other": "Other",
     "language": "Language",
@@ -700,7 +697,10 @@
       "explanation": "If you proceed, all data will be deleted from your Yivi app. If you wish to continue using Yivi you will have to reload the data.",
       "confirm": "Yes, delete everything",
       "deny": "Cancel"
-    }
+    },
+    "biometric_unlock": "Unlock with biometrics",
+    "biometric_unlock_explanation": "Use Face ID, Touch ID or fingerprint to open Yivi.",
+    "biometric_unlock_prompt": "Confirm to enable"
   },
   "ui": {
     "loading": "Loading…",

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -276,6 +276,13 @@
     "confirm_pin": {
       "instruction": "Enter your PIN again"
     },
+    "biometric": {
+      "title": "Open Yivi with your biometrics",
+      "explanation": "You can use Face ID, Touch ID or your fingerprint to open the Yivi app instead of typing your PIN every time. You will still be asked for your PIN when you share or receive credentials.",
+      "privacy": "Your biometric information stays on this device. It is never shared with Yivi, with issuers, or with the parties you share credentials with. Biometrics are only used to unlock the Yivi app on your phone.",
+      "enable": "Use biometrics",
+      "skip": "Not now"
+    },
     "email": {
       "provide": {
         "title": "Add e-mail address",
@@ -553,7 +560,13 @@
   "pin": {
     "subtitle": "Enter your PIN",
     "button_forgot": "I forgot my PIN",
-    "button_block": "Block Yivi"
+    "button_block": "Block Yivi",
+    "biometric": {
+      "reason": "Unlock Yivi",
+      "android_title": "Scan your biometrics to unlock Yivi",
+      "lockout": "Biometric authentication is unavailable. Enter your PIN instead.",
+      "retry": "Unlock with biometrics"
+    }
   },
   "pin_accessibility": {
     "show_pin": "Show PIN",
@@ -672,6 +685,9 @@
     "report_errors_explanation": "By enabling error and app status reporting you are helping us improve the user experience.",
     "enable_screenshots": "Enable screenshots",
     "enable_screenshots_explanation": "When enabled, the app will not be blurred in the app switcher.",
+    "biometric_unlock": "Unlock with biometrics",
+    "biometric_unlock_explanation": "Use Face ID, Touch ID or your fingerprint to open Yivi. Your PIN is still required when sharing or receiving credentials.",
+    "biometric_unlock_prompt": "Confirm to enable biometric unlock",
     "developer_mode": "Developer mode",
     "other": "Other",
     "language": "Language",

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -323,9 +323,9 @@
       "progress_enrollment": "Welcome! Please wait a moment, we're signing you up."
     },
     "biometric": {
-      "title": "Open Yivi with biometrics",
-      "explanation": "Use Face ID, Touch ID or fingerprint to open Yivi. Your PIN is still required to share or receive credentials.",
-      "privacy": "Your biometrics stay on this device and are never shared with Yivi, issuers, or parties you share credentials with.",
+      "title": "Open Yivi with your biometrics",
+      "explanation": "You can use Face ID, Touch ID or your fingerprint to open the Yivi app instead of typing your PIN every time. You will still be asked for your PIN when you share or receive credentials.",
+      "privacy": "Your biometric information stays on this device. It is never shared with Yivi, with issuers, or with the parties you share credentials with. Biometrics are only used to unlock the Yivi app on your phone.",
       "enable": "Use biometrics",
       "skip": "Not now"
     }
@@ -562,9 +562,9 @@
     "button_forgot": "I forgot my PIN",
     "button_block": "Block Yivi",
     "biometric": {
-      "reason": "Open Yivi",
+      "reason": "Unlock Yivi",
       "android_title": "Scan your biometrics to unlock Yivi",
-      "lockout": "Biometric authentication unavailable. Enter your PIN.",
+      "lockout": "Biometric authentication is unavailable. Enter your PIN instead.",
       "retry": "Unlock with biometrics"
     }
   },
@@ -698,8 +698,8 @@
       "deny": "Cancel"
     },
     "biometric_unlock": "Unlock with biometrics",
-    "biometric_unlock_explanation": "Use Face ID, Touch ID or fingerprint to open Yivi.",
-    "biometric_unlock_prompt": "Confirm to enable"
+    "biometric_unlock_explanation": "Use Face ID, Touch ID or your fingerprint to open Yivi. Your PIN is still required when sharing or receiving credentials.",
+    "biometric_unlock_prompt": "Confirm to enable biometric unlock"
   },
   "ui": {
     "loading": "Loading…",

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -278,6 +278,13 @@
     "confirm_pin": {
       "instruction": "Enter your PIN again"
     },
+    "biometric": {
+      "title": "Open Yivi with your biometrics",
+      "explanation": "You can use Face ID, Touch ID or your fingerprint to open the Yivi app instead of typing your PIN every time. You will still be asked for your PIN when you share or receive credentials.",
+      "privacy": "Your biometric information stays on this device. It is never shared with Yivi, with issuers, or with the parties you share credentials with. Biometrics are only used to unlock the Yivi app on your phone.",
+      "enable": "Use biometrics",
+      "skip": "Not now"
+    },
     "email": {
       "provide": {
         "title": "Add e-mail address",
@@ -554,7 +561,13 @@
   "pin": {
     "subtitle": "Enter your PIN",
     "button_forgot": "I forgot my PIN",
-    "button_block": "Block Yivi"
+    "button_block": "Block Yivi",
+    "biometric": {
+      "reason": "Unlock Yivi",
+      "android_title": "Scan your biometrics to unlock Yivi",
+      "lockout": "Biometric authentication is unavailable. Enter your PIN instead.",
+      "retry": "Unlock with biometrics"
+    }
   },
   "pin_accessibility": {
     "show_pin": "Show PIN",
@@ -673,6 +686,9 @@
     "report_errors_explanation": "By enabling error and app status reporting you are helping us improve the user experience.",
     "enable_screenshots": "Enable screenshots",
     "enable_screenshots_explanation": "When enabled, the app will not be blurred in the app switcher.",
+    "biometric_unlock": "Unlock with biometrics",
+    "biometric_unlock_explanation": "Use Face ID, Touch ID or your fingerprint to open Yivi. Your PIN is still required when sharing or receiving credentials.",
+    "biometric_unlock_prompt": "Confirm to enable biometric unlock",
     "developer_mode": "Developer mode",
     "other": "Other",
     "language": "Language",

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -276,13 +276,6 @@
     "confirm_pin": {
       "instruction": "Enter your PIN again"
     },
-    "biometric": {
-      "title": "Open Yivi with your biometrics",
-      "explanation": "You can use Face ID, Touch ID or your fingerprint to open the Yivi app instead of typing your PIN every time. You will still be asked for your PIN when you share or receive credentials.",
-      "privacy": "Your biometric information stays on this device. It is never shared with Yivi, with issuers, or with the parties you share credentials with. Biometrics are only used to unlock the Yivi app on your phone.",
-      "enable": "Use biometrics",
-      "skip": "Not now"
-    },
     "email": {
       "provide": {
         "title": "Add e-mail address",
@@ -328,6 +321,13 @@
     "submit": {
       "title": "Logging in",
       "progress_enrollment": "Welcome! Please wait a moment, we're signing you up."
+    },
+    "biometric": {
+      "title": "Open Yivi with biometrics",
+      "explanation": "Use Face ID, Touch ID or fingerprint to open Yivi. Your PIN is still required to share or receive credentials.",
+      "privacy": "Your biometrics stay on this device and are never shared with Yivi, issuers, or parties you share credentials with.",
+      "enable": "Use biometrics",
+      "skip": "Not now"
     }
   },
   "error": {
@@ -562,9 +562,9 @@
     "button_forgot": "I forgot my PIN",
     "button_block": "Block Yivi",
     "biometric": {
-      "reason": "Unlock Yivi",
+      "reason": "Open Yivi",
       "android_title": "Scan your biometrics to unlock Yivi",
-      "lockout": "Biometric authentication is unavailable. Enter your PIN instead.",
+      "lockout": "Biometric authentication unavailable. Enter your PIN.",
       "retry": "Unlock with biometrics"
     }
   },
@@ -685,9 +685,6 @@
     "report_errors_explanation": "By enabling error and app status reporting you are helping us improve the user experience.",
     "enable_screenshots": "Enable screenshots",
     "enable_screenshots_explanation": "When enabled, the app will not be blurred in the app switcher.",
-    "biometric_unlock": "Unlock with biometrics",
-    "biometric_unlock_explanation": "Use Face ID, Touch ID or your fingerprint to open Yivi. Your PIN is still required when sharing or receiving credentials.",
-    "biometric_unlock_prompt": "Confirm to enable biometric unlock",
     "developer_mode": "Developer mode",
     "other": "Other",
     "language": "Language",
@@ -699,7 +696,10 @@
       "explanation": "If you proceed, all data will be deleted from your Yivi app. If you wish to continue using Yivi you will have to reload the data.",
       "confirm": "Yes, delete everything",
       "deny": "Cancel"
-    }
+    },
+    "biometric_unlock": "Unlock with biometrics",
+    "biometric_unlock_explanation": "Use Face ID, Touch ID or fingerprint to open Yivi.",
+    "biometric_unlock_prompt": "Confirm to enable"
   },
   "ui": {
     "loading": "Loading…",

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -325,9 +325,9 @@
       "progress_enrollment": "Welcome! Please wait a moment, we're signing you up."
     },
     "biometric": {
-      "title": "Open Yivi with biometrics",
-      "explanation": "Use Face ID, Touch ID or fingerprint to open Yivi. Your PIN is still required to share or receive credentials.",
-      "privacy": "Your biometrics stay on this device and are never shared with Yivi, issuers, or parties you share credentials with.",
+      "title": "Open Yivi with your biometrics",
+      "explanation": "You can use Face ID, Touch ID or your fingerprint to open the Yivi app instead of typing your PIN every time. You will still be asked for your PIN when you share or receive credentials.",
+      "privacy": "Your biometric information stays on this device. It is never shared with Yivi, with issuers, or with the parties you share credentials with. Biometrics are only used to unlock the Yivi app on your phone.",
       "enable": "Use biometrics",
       "skip": "Not now"
     }
@@ -563,9 +563,9 @@
     "button_forgot": "I forgot my PIN",
     "button_block": "Block Yivi",
     "biometric": {
-      "reason": "Open Yivi",
+      "reason": "Unlock Yivi",
       "android_title": "Scan your biometrics to unlock Yivi",
-      "lockout": "Biometric authentication unavailable. Enter your PIN.",
+      "lockout": "Biometric authentication is unavailable. Enter your PIN instead.",
       "retry": "Unlock with biometrics"
     }
   },
@@ -699,8 +699,8 @@
       "deny": "Cancel"
     },
     "biometric_unlock": "Unlock with biometrics",
-    "biometric_unlock_explanation": "Use Face ID, Touch ID or fingerprint to open Yivi.",
-    "biometric_unlock_prompt": "Confirm to enable"
+    "biometric_unlock_explanation": "Use Face ID, Touch ID or your fingerprint to open Yivi. Your PIN is still required when sharing or receiving credentials.",
+    "biometric_unlock_prompt": "Confirm to enable biometric unlock"
   },
   "ui": {
     "loading": "Loading…",

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -323,9 +323,9 @@
       "progress_enrollment": "Welkom! Even geduld, we melden je aan."
     },
     "biometric": {
-      "title": "Open Yivi met biometrie",
-      "explanation": "Gebruik Face ID, Touch ID of vingerafdruk om Yivi te openen. Je pincode blijft nodig bij delen of ontvangen.",
-      "privacy": "Je biometrie blijft op dit toestel en wordt nooit gedeeld met Yivi, uitgevers of partijen waarmee je gegevens deelt.",
+      "title": "Open Yivi met je biometrie",
+      "explanation": "Je kunt Face ID, Touch ID of je vingerafdruk gebruiken om de Yivi-app te openen, zodat je niet steeds je pincode hoeft in te typen. Je pincode blijft wel nodig wanneer je kaartjes deelt of ontvangt.",
+      "privacy": "Je biometrische gegevens blijven op dit toestel. Ze worden niet gedeeld met Yivi, niet met uitgevers en ook niet met de partijen waarmee je gegevens deelt. Biometrie wordt alleen gebruikt om de Yivi-app op je telefoon te openen.",
       "enable": "Gebruik biometrie",
       "skip": "Niet nu"
     }
@@ -563,8 +563,8 @@
     "button_block": "Yivi blokkeren",
     "biometric": {
       "reason": "Open Yivi",
-      "android_title": "Scan biometrie om Yivi te openen",
-      "lockout": "Biometrie niet beschikbaar. Voer je pincode in.",
+      "android_title": "Scan je biometrie om Yivi te openen",
+      "lockout": "Biometrische verificatie is niet beschikbaar. Voer je pincode in.",
       "retry": "Open met biometrie"
     }
   },
@@ -698,8 +698,8 @@
       "deny": "Annuleer"
     },
     "biometric_unlock": "Openen met biometrie",
-    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of vingerafdruk om Yivi te openen.",
-    "biometric_unlock_prompt": "Bevestig om in te schakelen"
+    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of je vingerafdruk om Yivi te openen. Je pincode blijft nodig bij het delen of ontvangen van kaartjes.",
+    "biometric_unlock_prompt": "Bevestig om biometrisch openen in te schakelen"
   },
   "ui": {
     "loading": "Laden…",

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -276,13 +276,6 @@
     "confirm_pin": {
       "instruction": "Vul je pincode nog een keer in"
     },
-    "biometric": {
-      "title": "Open Yivi met je biometrie",
-      "explanation": "Je kunt Face ID, Touch ID of je vingerafdruk gebruiken om de Yivi-app te openen, zodat je niet steeds je pincode hoeft in te typen. Je pincode blijft wel nodig wanneer je kaartjes deelt of ontvangt.",
-      "privacy": "Je biometrische gegevens blijven op dit toestel. Ze worden niet gedeeld met Yivi, niet met uitgevers en ook niet met de partijen waarmee je gegevens deelt. Biometrie wordt alleen gebruikt om de Yivi-app op je telefoon te openen.",
-      "enable": "Gebruik biometrie",
-      "skip": "Niet nu"
-    },
     "email": {
       "provide": {
         "title": "E-mailadres toevoegen",
@@ -328,6 +321,13 @@
     "submit": {
       "title": "Aanmelden",
       "progress_enrollment": "Welkom! Even geduld, we melden je aan."
+    },
+    "biometric": {
+      "title": "Open Yivi met biometrie",
+      "explanation": "Gebruik Face ID, Touch ID of vingerafdruk om Yivi te openen. Je pincode blijft nodig bij delen of ontvangen.",
+      "privacy": "Je biometrie blijft op dit toestel en wordt nooit gedeeld met Yivi, uitgevers of partijen waarmee je gegevens deelt.",
+      "enable": "Gebruik biometrie",
+      "skip": "Niet nu"
     }
   },
   "error": {
@@ -562,9 +562,9 @@
     "button_forgot": "Pincode vergeten",
     "button_block": "Yivi blokkeren",
     "biometric": {
-      "reason": "Open Yivi reason",
-      "android_title": "Scan je biometrie om Yivi te openen",
-      "lockout": "Biometrische verificatie is niet beschikbaar. Voer je pincode in.",
+      "reason": "Open Yivi",
+      "android_title": "Scan biometrie om Yivi te openen",
+      "lockout": "Biometrie niet beschikbaar. Voer je pincode in.",
       "retry": "Open met biometrie"
     }
   },
@@ -685,9 +685,6 @@
     "report_errors_explanation": "Door deze informatie te delen help je ons de gebruikservaring te verbeteren.",
     "enable_screenshots": "Screenshots toestaan",
     "enable_screenshots_explanation": "Als dit is ingeschakeld, wordt de app niet vervaagd in de app-switcher.",
-    "biometric_unlock": "Openen met biometrie",
-    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of je vingerafdruk om Yivi te openen. Je pincode blijft nodig bij het delen of ontvangen van kaartjes.",
-    "biometric_unlock_prompt": "Bevestig om biometrisch openen in te schakelen",
     "developer_mode": "Developer modus",
     "other": "Overig",
     "language": "Taal",
@@ -699,7 +696,10 @@
       "explanation": "Als je doorgaat, verwijder je al je gegevens en je toegang tot de Yivi-app. Wil je de Yivi-app opnieuw gebruiken? Kies een nieuwe pincode en haal je gegevens opnieuw op.",
       "confirm": "Verwijder alles",
       "deny": "Annuleer"
-    }
+    },
+    "biometric_unlock": "Openen met biometrie",
+    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of vingerafdruk om Yivi te openen.",
+    "biometric_unlock_prompt": "Bevestig om in te schakelen"
   },
   "ui": {
     "loading": "Laden…",

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -325,9 +325,9 @@
       "progress_enrollment": "Welkom! Even geduld, we melden je aan."
     },
     "biometric": {
-      "title": "Open Yivi met biometrie",
-      "explanation": "Gebruik Face ID, Touch ID of vingerafdruk om Yivi te openen. Je pincode blijft nodig bij delen of ontvangen.",
-      "privacy": "Je biometrie blijft op dit toestel en wordt nooit gedeeld met Yivi, uitgevers of partijen waarmee je gegevens deelt.",
+      "title": "Open Yivi met je biometrie",
+      "explanation": "Je kunt Face ID, Touch ID of je vingerafdruk gebruiken om de Yivi-app te openen, zodat je niet steeds je pincode hoeft in te typen. Je pincode blijft wel nodig wanneer je kaartjes deelt of ontvangt.",
+      "privacy": "Je biometrische gegevens blijven op dit toestel. Ze worden niet gedeeld met Yivi, niet met uitgevers en ook niet met de partijen waarmee je gegevens deelt. Biometrie wordt alleen gebruikt om de Yivi-app op je telefoon te openen.",
       "enable": "Gebruik biometrie",
       "skip": "Niet nu"
     }
@@ -564,8 +564,8 @@
     "button_block": "Yivi blokkeren",
     "biometric": {
       "reason": "Open Yivi",
-      "android_title": "Scan biometrie om Yivi te openen",
-      "lockout": "Biometrie niet beschikbaar. Voer je pincode in.",
+      "android_title": "Scan je biometrie om Yivi te openen",
+      "lockout": "Biometrische verificatie is niet beschikbaar. Voer je pincode in.",
       "retry": "Open met biometrie"
     }
   },
@@ -699,8 +699,8 @@
       "deny": "Annuleer"
     },
     "biometric_unlock": "Openen met biometrie",
-    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of vingerafdruk om Yivi te openen.",
-    "biometric_unlock_prompt": "Bevestig om in te schakelen"
+    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of je vingerafdruk om Yivi te openen. Je pincode blijft nodig bij het delen of ontvangen van kaartjes.",
+    "biometric_unlock_prompt": "Bevestig om biometrisch openen in te schakelen"
   },
   "ui": {
     "loading": "Laden…",

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -278,13 +278,6 @@
     "confirm_pin": {
       "instruction": "Vul je pincode nog een keer in"
     },
-    "biometric": {
-      "title": "Open Yivi met je biometrie",
-      "explanation": "Je kunt Face ID, Touch ID of je vingerafdruk gebruiken om de Yivi-app te openen, zodat je niet steeds je pincode hoeft in te typen. Je pincode blijft wel nodig wanneer je kaartjes deelt of ontvangt.",
-      "privacy": "Je biometrische gegevens blijven op dit toestel. Ze worden niet gedeeld met Yivi, niet met uitgevers en ook niet met de partijen waarmee je gegevens deelt. Biometrie wordt alleen gebruikt om de Yivi-app op je telefoon te openen.",
-      "enable": "Gebruik biometrie",
-      "skip": "Niet nu"
-    },
     "email": {
       "provide": {
         "title": "E-mailadres toevoegen",
@@ -330,6 +323,13 @@
     "submit": {
       "title": "Aanmelden",
       "progress_enrollment": "Welkom! Even geduld, we melden je aan."
+    },
+    "biometric": {
+      "title": "Open Yivi met biometrie",
+      "explanation": "Gebruik Face ID, Touch ID of vingerafdruk om Yivi te openen. Je pincode blijft nodig bij delen of ontvangen.",
+      "privacy": "Je biometrie blijft op dit toestel en wordt nooit gedeeld met Yivi, uitgevers of partijen waarmee je gegevens deelt.",
+      "enable": "Gebruik biometrie",
+      "skip": "Niet nu"
     }
   },
   "error": {
@@ -563,9 +563,9 @@
     "button_forgot": "Pincode vergeten",
     "button_block": "Yivi blokkeren",
     "biometric": {
-      "reason": "Open Yivi reason",
-      "android_title": "Scan je biometrie om Yivi te openen",
-      "lockout": "Biometrische verificatie is niet beschikbaar. Voer je pincode in.",
+      "reason": "Open Yivi",
+      "android_title": "Scan biometrie om Yivi te openen",
+      "lockout": "Biometrie niet beschikbaar. Voer je pincode in.",
       "retry": "Open met biometrie"
     }
   },
@@ -686,9 +686,6 @@
     "report_errors_explanation": "Door deze informatie te delen help je ons de gebruikservaring te verbeteren.",
     "enable_screenshots": "Screenshots toestaan",
     "enable_screenshots_explanation": "Als dit is ingeschakeld, wordt de app niet vervaagd in de app-switcher.",
-    "biometric_unlock": "Openen met biometrie",
-    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of je vingerafdruk om Yivi te openen. Je pincode blijft nodig bij het delen of ontvangen van kaartjes.",
-    "biometric_unlock_prompt": "Bevestig om biometrisch openen in te schakelen",
     "developer_mode": "Developer modus",
     "other": "Overig",
     "language": "Taal",
@@ -700,7 +697,10 @@
       "explanation": "Als je doorgaat, verwijder je al je gegevens en je toegang tot de Yivi-app. Wil je de Yivi-app opnieuw gebruiken? Kies een nieuwe pincode en haal je gegevens opnieuw op.",
       "confirm": "Verwijder alles",
       "deny": "Annuleer"
-    }
+    },
+    "biometric_unlock": "Openen met biometrie",
+    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of vingerafdruk om Yivi te openen.",
+    "biometric_unlock_prompt": "Bevestig om in te schakelen"
   },
   "ui": {
     "loading": "Laden…",

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -278,6 +278,13 @@
     "confirm_pin": {
       "instruction": "Vul je pincode nog een keer in"
     },
+    "biometric": {
+      "title": "Open Yivi met je biometrie",
+      "explanation": "Je kunt Face ID, Touch ID of je vingerafdruk gebruiken om de Yivi-app te openen, zodat je niet steeds je pincode hoeft in te typen. Je pincode blijft wel nodig wanneer je kaartjes deelt of ontvangt.",
+      "privacy": "Je biometrische gegevens blijven op dit toestel. Ze worden niet gedeeld met Yivi, niet met uitgevers en ook niet met de partijen waarmee je gegevens deelt. Biometrie wordt alleen gebruikt om de Yivi-app op je telefoon te openen.",
+      "enable": "Gebruik biometrie",
+      "skip": "Niet nu"
+    },
     "email": {
       "provide": {
         "title": "E-mailadres toevoegen",
@@ -554,7 +561,13 @@
   "pin": {
     "subtitle": "Voer je pincode in",
     "button_forgot": "Pincode vergeten",
-    "button_block": "Yivi blokkeren"
+    "button_block": "Yivi blokkeren",
+    "biometric": {
+      "reason": "Open Yivi reason",
+      "android_title": "Scan je biometrie om Yivi te openen",
+      "lockout": "Biometrische verificatie is niet beschikbaar. Voer je pincode in.",
+      "retry": "Open met biometrie"
+    }
   },
   "pin_accessibility": {
     "show_pin": "Toon pincode",
@@ -673,6 +686,9 @@
     "report_errors_explanation": "Door deze informatie te delen help je ons de gebruikservaring te verbeteren.",
     "enable_screenshots": "Screenshots toestaan",
     "enable_screenshots_explanation": "Als dit is ingeschakeld, wordt de app niet vervaagd in de app-switcher.",
+    "biometric_unlock": "Openen met biometrie",
+    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of je vingerafdruk om Yivi te openen. Je pincode blijft nodig bij het delen of ontvangen van kaartjes.",
+    "biometric_unlock_prompt": "Bevestig om biometrisch openen in te schakelen",
     "developer_mode": "Developer modus",
     "other": "Overig",
     "language": "Taal",

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -276,6 +276,13 @@
     "confirm_pin": {
       "instruction": "Vul je pincode nog een keer in"
     },
+    "biometric": {
+      "title": "Open Yivi met je biometrie",
+      "explanation": "Je kunt Face ID, Touch ID of je vingerafdruk gebruiken om de Yivi-app te openen, zodat je niet steeds je pincode hoeft in te typen. Je pincode blijft wel nodig wanneer je kaartjes deelt of ontvangt.",
+      "privacy": "Je biometrische gegevens blijven op dit toestel. Ze worden niet gedeeld met Yivi, niet met uitgevers en ook niet met de partijen waarmee je gegevens deelt. Biometrie wordt alleen gebruikt om de Yivi-app op je telefoon te openen.",
+      "enable": "Gebruik biometrie",
+      "skip": "Niet nu"
+    },
     "email": {
       "provide": {
         "title": "E-mailadres toevoegen",
@@ -553,7 +560,13 @@
   "pin": {
     "subtitle": "Voer je pincode in",
     "button_forgot": "Pincode vergeten",
-    "button_block": "Yivi blokkeren"
+    "button_block": "Yivi blokkeren",
+    "biometric": {
+      "reason": "Open Yivi reason",
+      "android_title": "Scan je biometrie om Yivi te openen",
+      "lockout": "Biometrische verificatie is niet beschikbaar. Voer je pincode in.",
+      "retry": "Open met biometrie"
+    }
   },
   "pin_accessibility": {
     "show_pin": "Toon pincode",
@@ -672,6 +685,9 @@
     "report_errors_explanation": "Door deze informatie te delen help je ons de gebruikservaring te verbeteren.",
     "enable_screenshots": "Screenshots toestaan",
     "enable_screenshots_explanation": "Als dit is ingeschakeld, wordt de app niet vervaagd in de app-switcher.",
+    "biometric_unlock": "Openen met biometrie",
+    "biometric_unlock_explanation": "Gebruik Face ID, Touch ID of je vingerafdruk om Yivi te openen. Je pincode blijft nodig bij het delen of ontvangen van kaartjes.",
+    "biometric_unlock_prompt": "Bevestig om biometrisch openen in te schakelen",
     "developer_mode": "Developer modus",
     "other": "Overig",
     "language": "Taal",

--- a/yivi_core/lib/routing.dart
+++ b/yivi_core/lib/routing.dart
@@ -110,6 +110,7 @@ GoRouter createRouter(BuildContext buildContext, WidgetRef ref) {
                 return TermsChangedListener(
                   child: PinScreen(
                     onAuthenticated: context.goHomeScreenWithoutTransition,
+                    allowBiometricBypass: true,
                     leading: YiviAppBarQrCodeButton(
                       onTap: () => openQrCodeScanner(
                         context,

--- a/yivi_core/lib/routing.dart
+++ b/yivi_core/lib/routing.dart
@@ -118,6 +118,7 @@ GoRouter createRouter(BuildContext buildContext, WidgetRef ref) {
                       context.read<HomeTabState>().add(IrmaNavBarTab.data);
                       context.goHomeScreenWithoutTransition();
                     },
+                    allowBiometricBypass: true,
                     leading: YiviAppBarQrCodeButton(
                       onTap: () => openQrCodeScanner(
                         context,

--- a/yivi_core/lib/src/data/irma_preferences.dart
+++ b/yivi_core/lib/src/data/irma_preferences.dart
@@ -54,6 +54,10 @@ class IrmaPreferences {
        _credentialOrder = preferences.getStringList(
          _credentialOrderKey,
          defaultValue: [],
+       ),
+       _biometricUnlockEnabled = preferences.getBool(
+         _biometricUnlockEnabledKey,
+         defaultValue: false,
        ) {
     // Remove unused IRMA -> Yivi name change notification key
     preferences.remove(_showNameChangeNotificationKey);
@@ -126,6 +130,10 @@ class IrmaPreferences {
   // list of credential ids stored as json string
   final Preference<List<String>> _credentialOrder;
 
+  static const String _biometricUnlockEnabledKey =
+      "preference.biometric_unlock_enabled";
+  final Preference<bool> _biometricUnlockEnabled;
+
   // =============================================================================
 
   Stream<bool> getScreenshotsEnabled() => _screenshotsEnabled;
@@ -189,6 +197,13 @@ class IrmaPreferences {
 
   Future<bool> setCredentialOrder(List<String> order) =>
       _credentialOrder.setValue(order);
+
+  Stream<bool> getBiometricUnlockEnabled() => _biometricUnlockEnabled;
+
+  bool getBiometricUnlockEnabledSync() => _biometricUnlockEnabled.getValue();
+
+  Future<bool> setBiometricUnlockEnabled(bool value) =>
+      _biometricUnlockEnabled.setValue(value);
 
   Future<void> clearAll() {
     // Reset all preferences to their default values

--- a/yivi_core/lib/src/data/irma_repository.dart
+++ b/yivi_core/lib/src/data/irma_repository.dart
@@ -396,6 +396,15 @@ class IrmaRepository {
     _blockedSubject.add(unblockTime);
   }
 
+  /// Bypass the local lock screen using platform-native biometric
+  /// authentication. This does NOT authenticate against the keyshare server;
+  /// any operation that talks to the keyshare server (issuance, disclosure)
+  /// will still trigger a session pin entry.
+  void unlockWithBiometrics() {
+    _lockedSubject.add(false);
+    _blockedSubject.add(null);
+  }
+
   void setDeveloperMode(bool enabled) {
     bridgedDispatch(
       ClientPreferencesEvent(

--- a/yivi_core/lib/src/data/irma_repository.dart
+++ b/yivi_core/lib/src/data/irma_repository.dart
@@ -358,6 +358,15 @@ class IrmaRepository {
     _blockedSubject.add(unblockTime);
   }
 
+  /// Bypass the local lock screen using platform-native biometric
+  /// authentication. This does NOT authenticate against the keyshare server;
+  /// any operation that talks to the keyshare server (issuance, disclosure)
+  /// will still trigger a session pin entry.
+  void unlockWithBiometrics() {
+    _lockedSubject.add(false);
+    _blockedSubject.add(null);
+  }
+
   void setDeveloperMode(bool enabled) {
     bridgedDispatch(
       ClientPreferencesEvent(

--- a/yivi_core/lib/src/screens/enrollment/biometric_setup/biometric_setup_screen.dart
+++ b/yivi_core/lib/src/screens/enrollment/biometric_setup/biometric_setup_screen.dart
@@ -1,0 +1,110 @@
+import "package:flutter/material.dart";
+import "package:flutter_i18n/flutter_i18n.dart";
+
+import "../../../theme/theme.dart";
+import "../../../util/biometric_auth.dart";
+import "../../../widgets/irma_bottom_bar.dart";
+import "../../../widgets/translated_text.dart";
+
+class BiometricSetupScreen extends StatefulWidget {
+  final VoidCallback onEnable;
+  final VoidCallback onSkip;
+  final VoidCallback onPrevious;
+
+  const BiometricSetupScreen({
+    super.key,
+    required this.onEnable,
+    required this.onSkip,
+    required this.onPrevious,
+  });
+
+  @override
+  State<BiometricSetupScreen> createState() => _BiometricSetupScreenState();
+}
+
+class _BiometricSetupScreenState extends State<BiometricSetupScreen> {
+  final BiometricAuth _biometricAuth = BiometricAuth();
+  bool _busy = false;
+
+  Future<void> _onEnablePressed() async {
+    if (_busy) return;
+    setState(() => _busy = true);
+    final reason = FlutterI18n.translate(context, "pin.biometric.reason");
+    final signInTitle = FlutterI18n.translate(
+      context,
+      "pin.biometric.android_title",
+    );
+    final cancel = FlutterI18n.translate(context, "ui.cancel");
+    final lockOut = FlutterI18n.translate(context, "pin.biometric.lockout");
+    final result = await _biometricAuth.authenticate(
+      reason: reason,
+      androidSignInTitle: signInTitle,
+      androidCancelButton: cancel,
+      iosCancelButton: cancel,
+      iosLockoutMessage: lockOut,
+    );
+    if (!mounted) return;
+    setState(() => _busy = false);
+    if (result.success) {
+      widget.onEnable();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = IrmaTheme.of(context);
+    return Scaffold(
+      backgroundColor: theme.backgroundSecondary,
+      body: SafeArea(
+        child: LayoutBuilder(
+          builder: (context, constraints) => SingleChildScrollView(
+            child: ConstrainedBox(
+              constraints: BoxConstraints(minHeight: constraints.maxHeight),
+              child: IntrinsicHeight(
+                child: Padding(
+                  padding: EdgeInsets.all(theme.mediumSpacing),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      SizedBox(height: theme.mediumSpacing),
+                      Center(
+                        child: Icon(
+                          Icons.fingerprint,
+                          size: 96,
+                          color: theme.primary,
+                        ),
+                      ),
+                      SizedBox(height: theme.mediumSpacing),
+                      TranslatedText(
+                        "enrollment.biometric.title",
+                        style: theme.textTheme.displayLarge,
+                        textAlign: TextAlign.start,
+                      ),
+                      SizedBox(height: theme.mediumSpacing),
+                      const TranslatedText(
+                        "enrollment.biometric.explanation",
+                        textAlign: TextAlign.start,
+                      ),
+                      SizedBox(height: theme.defaultSpacing),
+                      const TranslatedText(
+                        "enrollment.biometric.privacy",
+                        textAlign: TextAlign.start,
+                      ),
+                      const Spacer(),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+      bottomNavigationBar: IrmaBottomBar(
+        primaryButtonLabel: "enrollment.biometric.enable",
+        onPrimaryPressed: _busy ? null : _onEnablePressed,
+        secondaryButtonLabel: "enrollment.biometric.skip",
+        onSecondaryPressed: _busy ? null : widget.onSkip,
+      ),
+    );
+  }
+}

--- a/yivi_core/lib/src/screens/enrollment/bloc/enrollment_bloc.dart
+++ b/yivi_core/lib/src/screens/enrollment/bloc/enrollment_bloc.dart
@@ -3,6 +3,7 @@ import "package:flutter_bloc/flutter_bloc.dart";
 import "../../../data/irma_repository.dart";
 import "../../../models/enrollment_events.dart";
 import "../../../models/session.dart";
+import "../../../util/biometric_auth.dart";
 import "../introduction/introduction_screen.dart";
 
 part "enrollment_event.dart";
@@ -11,12 +12,17 @@ part "enrollment_state.dart";
 class EnrollmentBloc extends Bloc<EnrollmentBlocEvent, EnrollmentState> {
   final String language;
   final IrmaRepository repo;
+  final BiometricAuth biometricAuth;
 
   String? _email;
   String? _pin;
 
-  EnrollmentBloc({required this.language, required this.repo})
-    : super(EnrollmentIntroduction());
+  EnrollmentBloc({
+    required this.language,
+    required this.repo,
+    BiometricAuth? biometricAuth,
+  }) : biometricAuth = biometricAuth ?? BiometricAuth(),
+       super(EnrollmentIntroduction());
 
   Future<EnrollmentState> _enroll() async {
     var enrollment = await repo.enroll(
@@ -93,10 +99,28 @@ class EnrollmentBloc extends Bloc<EnrollmentBlocEvent, EnrollmentState> {
       }
       if (event is EnrollmentPinConfirmed) {
         if (_pin == event.pin) {
-          yield EnrollmentProvideEmail();
+          // Offer biometric unlock only on devices that actually support it,
+          // otherwise skip straight to the email step.
+          if (await biometricAuth.canAuthenticate()) {
+            yield EnrollmentBiometricSetup();
+          } else {
+            yield EnrollmentProvideEmail();
+          }
         } else {
           yield EnrollmentConfirmPin(confirmationFailed: true);
         }
+      } else if (event is EnrollmentPreviousPressed) {
+        yield EnrollmentChoosePin();
+      }
+    }
+    // Biometric unlock setup
+    else if (state is EnrollmentBiometricSetup) {
+      if (event is EnrollmentBiometricEnabled) {
+        await repo.preferences.setBiometricUnlockEnabled(true);
+        yield EnrollmentProvideEmail();
+      } else if (event is EnrollmentBiometricSkipped) {
+        await repo.preferences.setBiometricUnlockEnabled(false);
+        yield EnrollmentProvideEmail();
       } else if (event is EnrollmentPreviousPressed) {
         yield EnrollmentChoosePin();
       }
@@ -109,7 +133,13 @@ class EnrollmentBloc extends Bloc<EnrollmentBlocEvent, EnrollmentState> {
         yield await _enroll();
       }
       if (event is EnrollmentPreviousPressed) {
-        yield EnrollmentChoosePin();
+        // Step back through the biometric prompt if the device supports it,
+        // otherwise jump to pin selection like before.
+        if (await biometricAuth.canAuthenticate()) {
+          yield EnrollmentBiometricSetup();
+        } else {
+          yield EnrollmentChoosePin();
+        }
       }
     } else if (state is EnrollmentEmailSent) {
       if (event is EnrollmentNextPressed) {

--- a/yivi_core/lib/src/screens/enrollment/bloc/enrollment_event.dart
+++ b/yivi_core/lib/src/screens/enrollment/bloc/enrollment_event.dart
@@ -28,6 +28,10 @@ class EnrollmentEmailProvided implements EnrollmentBlocEvent {
 
 class EnrollmentEmailSkipped implements EnrollmentBlocEvent {}
 
+class EnrollmentBiometricEnabled implements EnrollmentBlocEvent {}
+
+class EnrollmentBiometricSkipped implements EnrollmentBlocEvent {}
+
 class EnrollmentNextPressed implements EnrollmentBlocEvent {}
 
 class EnrollmentPreviousPressed implements EnrollmentBlocEvent {}

--- a/yivi_core/lib/src/screens/enrollment/bloc/enrollment_state.dart
+++ b/yivi_core/lib/src/screens/enrollment/bloc/enrollment_state.dart
@@ -16,6 +16,8 @@ class EnrollmentConfirmPin extends EnrollmentState {
   EnrollmentConfirmPin({this.confirmationFailed = false});
 }
 
+class EnrollmentBiometricSetup extends EnrollmentState {}
+
 class EnrollmentProvideEmail extends EnrollmentState {
   final String? email;
 

--- a/yivi_core/lib/src/screens/enrollment/enrollment_screen.dart
+++ b/yivi_core/lib/src/screens/enrollment/enrollment_screen.dart
@@ -9,6 +9,7 @@ import "../../providers/irma_repository_provider.dart";
 import "../../util/navigation.dart";
 import "../../widgets/loading_indicator.dart";
 import "accept_terms/accept_terms_screen.dart";
+import "biometric_setup/biometric_setup_screen.dart";
 import "bloc/enrollment_bloc.dart";
 import "choose_pin/choose_pin_screen.dart";
 import "confirm_pin/confirm_pin_screen.dart";
@@ -110,6 +111,13 @@ class _ProvidedEnrollmentScreen extends StatelessWidget {
                   ),
                 );
               },
+            );
+          }
+          if (state is EnrollmentBiometricSetup) {
+            return BiometricSetupScreen(
+              onEnable: () => addEvent(EnrollmentBiometricEnabled()),
+              onSkip: () => addEvent(EnrollmentBiometricSkipped()),
+              onPrevious: addOnPreviousPressed,
             );
           }
           if (state is EnrollmentProvideEmail) {

--- a/yivi_core/lib/src/screens/pin/number_pad.dart
+++ b/yivi_core/lib/src/screens/pin/number_pad.dart
@@ -2,12 +2,26 @@ part of "yivi_pin_screen.dart";
 
 class _NumberPad extends StatelessWidget {
   final NumberCallback onEnterNumber;
-  const _NumberPad({required this.onEnterNumber});
+  final VoidCallback? onBiometricTap;
+  const _NumberPad({required this.onEnterNumber, this.onBiometricTap});
 
   @override
   Widget build(BuildContext context) {
     return LayoutBuilder(
       builder: (context, constraints) {
+        final Widget bottomLeftSlot = onBiometricTap != null
+            ? Semantics(
+                button: true,
+                label: FlutterI18n.translate(
+                  context,
+                  "pin.biometric.retry",
+                ),
+                child: _NumberPadIcon(
+                  icon: Icons.fingerprint,
+                  callback: onBiometricTap!,
+                ),
+              )
+            : SizedBox.fromSize(size: const Size.square(20));
         final keys = <Widget>[
           // The empty String keeps the number aligned with the rest
           _NumberPadKey(onEnterNumber, 1, ""),
@@ -19,7 +33,7 @@ class _NumberPad extends StatelessWidget {
           _NumberPadKey(onEnterNumber, 7, "PQRS"),
           _NumberPadKey(onEnterNumber, 8, "TUV"),
           _NumberPadKey(onEnterNumber, 9, "WXYZ"),
-          SizedBox.fromSize(size: const Size.square(20)),
+          bottomLeftSlot,
           _NumberPadKey(onEnterNumber, 0),
           Semantics(
             button: true,

--- a/yivi_core/lib/src/screens/pin/number_pad.dart
+++ b/yivi_core/lib/src/screens/pin/number_pad.dart
@@ -12,10 +12,7 @@ class _NumberPad extends StatelessWidget {
         final Widget bottomLeftSlot = onBiometricTap != null
             ? Semantics(
                 button: true,
-                label: FlutterI18n.translate(
-                  context,
-                  "pin.biometric.retry",
-                ),
+                label: FlutterI18n.translate(context, "pin.biometric.retry"),
                 child: _NumberPadIcon(
                   icon: Icons.fingerprint,
                   callback: onBiometricTap!,

--- a/yivi_core/lib/src/screens/pin/pin_screen.dart
+++ b/yivi_core/lib/src/screens/pin/pin_screen.dart
@@ -5,7 +5,9 @@ import "package:flutter/services.dart";
 import "package:flutter_bloc/flutter_bloc.dart";
 import "package:flutter_i18n/flutter_i18n.dart";
 
+import "../../data/irma_repository.dart";
 import "../../providers/irma_repository_provider.dart";
+import "../../util/biometric_auth.dart";
 import "../../util/navigation.dart";
 import "../../widgets/irma_app_bar.dart";
 import "../../widgets/pin_common/format_blocked_for.dart";
@@ -21,12 +23,19 @@ class PinScreen extends StatefulWidget {
   final PinEvent? initialEvent;
   final Function() onAuthenticated;
   final Widget? leading;
+  // When true the user can opt to unlock the app with platform biometrics
+  // instead of entering the pin. This bypass only flips the local lock flag,
+  // it does NOT authenticate against the keyshare server, so it must remain
+  // false for any pin entry that precedes a keyshare interaction
+  // (issuance / disclosure / explicit pre-session auth).
+  final bool allowBiometricBypass;
 
   const PinScreen({
     super.key,
     required this.onAuthenticated,
     this.initialEvent,
     this.leading,
+    this.allowBiometricBypass = false,
   });
 
   @override
@@ -37,6 +46,9 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
   late final PinBloc _pinBloc;
 
   StreamSubscription? _pinBlocSubscription;
+  final BiometricAuth _biometricAuth = BiometricAuth();
+  bool _biometricAttempted = false;
+  bool _biometricAvailable = false;
 
   @override
   void initState() {
@@ -70,6 +82,10 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
       }
       _pinBloc.add(Blocked(blockedUntil));
     });
+
+    if (widget.allowBiometricBypass) {
+      _maybeStartBiometricUnlock(repo);
+    }
 
     _pinBlocSubscription = _pinBloc.stream.listen((pinState) async {
       if (pinState.authenticated) {
@@ -138,6 +154,57 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
         ),
       ),
     );
+  }
+
+  Future<void> _maybeStartBiometricUnlock(IrmaRepository repo) async {
+    if (!repo.preferences.getBiometricUnlockEnabledSync()) {
+      return;
+    }
+    final canAuth = await _biometricAuth.canAuthenticate();
+    if (!mounted) return;
+    if (!canAuth) {
+      // Device no longer supports biometrics (e.g. user removed all enrolled
+      // biometrics). Silently fall back to manual pin entry. The user can
+      // toggle the setting off from settings to make this case go away.
+      setState(() => _biometricAvailable = false);
+      return;
+    }
+    setState(() => _biometricAvailable = true);
+    await _runBiometricPrompt();
+  }
+
+  Future<void> _runBiometricPrompt() async {
+    if (_biometricAttempted) return;
+    _biometricAttempted = true;
+    final reason = FlutterI18n.translate(context, "pin.biometric.reason");
+    final signInTitle = FlutterI18n.translate(
+      context,
+      "pin.biometric.android_title",
+    );
+    final cancelAndroid = FlutterI18n.translate(context, "ui.cancel");
+    final cancelIos = FlutterI18n.translate(context, "ui.cancel");
+    final lockOut = FlutterI18n.translate(context, "pin.biometric.lockout");
+    final result = await _biometricAuth.authenticate(
+      reason: reason,
+      androidSignInTitle: signInTitle,
+      androidCancelButton: cancelAndroid,
+      iosCancelButton: cancelIos,
+      iosLockoutMessage: lockOut,
+    );
+    if (!mounted) return;
+    if (result.success) {
+      IrmaRepositoryProvider.of(context).unlockWithBiometrics();
+      widget.onAuthenticated();
+    } else {
+      // Allow the user to retry biometric via the inline button after a
+      // failure / cancellation.
+      _biometricAttempted = false;
+      if (result.unsupported) {
+        setState(() => _biometricAvailable = false);
+      } else {
+        setState(() {});
+      }
+    }
   }
 
   @override
@@ -217,6 +284,10 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
                         );
                       }
 
+                      final showBiometric =
+                          widget.allowBiometricBypass &&
+                          _biometricAvailable &&
+                          enabled;
                       return Stack(
                         alignment: Alignment.center,
                         children: [
@@ -227,6 +298,9 @@ class _PinScreenState extends State<PinScreen> with WidgetsBindingObserver {
                             pinBloc: pinBloc,
                             enabled: enabled,
                             onForgotPin: context.pushResetPinScreen,
+                            onBiometricTap: showBiometric
+                                ? _runBiometricPrompt
+                                : null,
                             listener: (context, state) {
                               if (maxPinSize == shortPinSize &&
                                   state.pin.length == maxPinSize &&

--- a/yivi_core/lib/src/screens/pin/yivi_pin_screen.dart
+++ b/yivi_core/lib/src/screens/pin/yivi_pin_screen.dart
@@ -73,6 +73,9 @@ class YiviPinScreen extends StatelessWidget {
   final void Function(BuildContext, EnterPinState)? listener;
   final WidgetVisibility Function(BuildContext, EnterPinState)?
   submitButtonVisibilityListener;
+  // Optional biometric unlock action. When non-null, a fingerprint key
+  // replaces the empty slot in the bottom-left of the number pad (under the 7).
+  final VoidCallback? onBiometricTap;
 
   YiviPinScreen({
     Key key = const Key("pin_screen"),
@@ -89,6 +92,7 @@ class YiviPinScreen extends StatelessWidget {
     this.enabled = true,
     this.listener,
     this.submitButtonVisibilityListener,
+    this.onBiometricTap,
   }) : assert(
          instructionKey != null && instruction == null ||
              instruction != null && instructionKey == null,
@@ -178,7 +182,12 @@ class YiviPinScreen extends StatelessWidget {
             },
           ),
         ),
-        Expanded(child: _NumberPad(onEnterNumber: pinBloc.add)),
+        Expanded(
+          child: _NumberPad(
+            onEnterNumber: pinBloc.add,
+            onBiometricTap: onBiometricTap,
+          ),
+        ),
       ],
     );
   }
@@ -246,7 +255,12 @@ class YiviPinScreen extends StatelessWidget {
             },
           ),
         ),
-        Expanded(child: _NumberPad(onEnterNumber: pinBloc.add)),
+        Expanded(
+          child: _NumberPad(
+            onEnterNumber: pinBloc.add,
+            onBiometricTap: onBiometricTap,
+          ),
+        ),
         if (maxPinSize != shortPinSize)
           Padding(
             padding: EdgeInsets.only(top: theme.screenPadding),

--- a/yivi_core/lib/src/screens/settings/settings_screen.dart
+++ b/yivi_core/lib/src/screens/settings/settings_screen.dart
@@ -2,10 +2,13 @@ import "dart:async";
 import "dart:io";
 
 import "package:flutter/material.dart";
+import "package:flutter_i18n/flutter_i18n.dart";
 
+import "../../data/irma_repository.dart";
 import "../../models/clear_all_data_event.dart";
 import "../../providers/irma_repository_provider.dart";
 import "../../theme/theme.dart";
+import "../../util/biometric_auth.dart";
 import "../../util/navigation.dart";
 import "../../widgets/irma_app_bar.dart";
 import "../../widgets/translated_text.dart";
@@ -20,6 +23,8 @@ class SettingsScreen extends StatefulWidget {
 
 class _SettingsScreenState extends State<SettingsScreen> {
   bool showDeveloperModeToggle = false;
+  bool biometricSupported = false;
+  final BiometricAuth _biometricAuth = BiometricAuth();
 
   @override
   void initState() {
@@ -40,6 +45,10 @@ class _SettingsScreenState extends State<SettingsScreen> {
           showDeveloperModeToggle = true;
         });
       }
+    });
+    _biometricAuth.canAuthenticate().then((supported) {
+      if (!mounted) return;
+      setState(() => biometricSupported = supported);
     });
   }
 
@@ -112,6 +121,21 @@ class _SettingsScreenState extends State<SettingsScreen> {
                 buildExplanationText("settings.enable_screenshots_explanation"),
                 spacerWidget,
               ],
+              if (biometricSupported) ...[
+                spacerWidget,
+                TilesCard(
+                  children: [
+                    ToggleTile(
+                      key: const Key("biometric_unlock_toggle"),
+                      labelTranslationKey: "settings.biometric_unlock",
+                      onChanged: (value) =>
+                          _onBiometricToggle(repo, value),
+                      stream: repo.preferences.getBiometricUnlockEnabled(),
+                    ),
+                  ],
+                ),
+                buildExplanationText("settings.biometric_unlock_explanation"),
+              ],
               if (showDeveloperModeToggle)
                 Padding(
                   padding: EdgeInsets.symmetric(vertical: theme.defaultSpacing),
@@ -152,6 +176,36 @@ class _SettingsScreenState extends State<SettingsScreen> {
         ),
       ),
     );
+  }
+
+  Future<void> _onBiometricToggle(IrmaRepository repo, bool enable) async {
+    if (!enable) {
+      await repo.preferences.setBiometricUnlockEnabled(false);
+      return;
+    }
+    final reason = FlutterI18n.translate(
+      context,
+      "settings.biometric_unlock_prompt",
+    );
+    final signInTitle = FlutterI18n.translate(
+      context,
+      "settings.biometric_unlock",
+    );
+    final cancel = FlutterI18n.translate(context, "ui.cancel");
+    final lockOut = FlutterI18n.translate(context, "pin.biometric.lockout");
+    final result = await _biometricAuth.authenticate(
+      reason: reason,
+      androidSignInTitle: signInTitle,
+      androidCancelButton: cancel,
+      iosCancelButton: cancel,
+      iosLockoutMessage: lockOut,
+    );
+    if (!mounted) return;
+    if (result.success) {
+      await repo.preferences.setBiometricUnlockEnabled(true);
+    } else if (result.unsupported) {
+      setState(() => biometricSupported = false);
+    }
   }
 }
 

--- a/yivi_core/lib/src/screens/settings/settings_screen.dart
+++ b/yivi_core/lib/src/screens/settings/settings_screen.dart
@@ -128,8 +128,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
                     ToggleTile(
                       key: const Key("biometric_unlock_toggle"),
                       labelTranslationKey: "settings.biometric_unlock",
-                      onChanged: (value) =>
-                          _onBiometricToggle(repo, value),
+                      onChanged: (value) => _onBiometricToggle(repo, value),
                       stream: repo.preferences.getBiometricUnlockEnabled(),
                     ),
                   ],

--- a/yivi_core/lib/src/util/biometric_auth.dart
+++ b/yivi_core/lib/src/util/biometric_auth.dart
@@ -1,0 +1,95 @@
+import "dart:async";
+import "dart:io";
+
+import "package:flutter/services.dart";
+import "package:local_auth/error_codes.dart" as auth_error;
+import "package:local_auth/local_auth.dart";
+import "package:local_auth_android/local_auth_android.dart";
+import "package:local_auth_darwin/types/auth_messages_ios.dart";
+
+class BiometricAuthResult {
+  final bool success;
+  final bool cancelled;
+  final bool unsupported;
+  final String? errorCode;
+
+  const BiometricAuthResult({
+    required this.success,
+    this.cancelled = false,
+    this.unsupported = false,
+    this.errorCode,
+  });
+}
+
+class BiometricAuth {
+  BiometricAuth({LocalAuthentication? auth})
+    : _auth = auth ?? LocalAuthentication();
+
+  final LocalAuthentication _auth;
+
+  Future<bool> canAuthenticate() async {
+    try {
+      final isSupported = await _auth.isDeviceSupported();
+      if (!isSupported) return false;
+      return _auth.canCheckBiometrics;
+    } on PlatformException {
+      return false;
+    }
+  }
+
+  Future<BiometricAuthResult> authenticate({
+    required String reason,
+    required String androidSignInTitle,
+    required String androidCancelButton,
+    required String iosCancelButton,
+    required String iosLockoutMessage,
+  }) async {
+    try {
+      // Android maps `localizedReason` to `BiometricPrompt.setDescription`,
+      // which renders as a third line under title + subtitle. We already
+      // show "Open Yivi" as the title, so a duplicate description is just
+      // visual noise. local_auth_android asserts `localizedReason.isNotEmpty`,
+      // so we can't fully omit it — pass a single space, which keeps the
+      // dialog row blank and lets the title carry the message.
+      // On iOS `localizedReason` IS the main prompt text and must be
+      // meaningful and non-empty, so we keep it there.
+      final localizedReason = Platform.isAndroid ? " " : reason;
+      final ok = await _auth.authenticate(
+        localizedReason: localizedReason,
+        options: const AuthenticationOptions(
+          stickyAuth: true,
+          // Force biometric-only so the OS won't offer its device PIN /
+          // passcode fallback — Yivi has its own PIN and showing the device
+          // passcode prompt next to it would be confusing.
+          biometricOnly: true,
+        ),
+        authMessages: [
+          AndroidAuthMessages(
+            signInTitle: androidSignInTitle,
+            cancelButton: androidCancelButton,
+            // Empty subtitle hides the "Verify identity" row that
+            // local_auth_android defaults to. BiometricPrompt sets the
+            // subtitle view's visibility to GONE when the string is empty.
+            biometricHint: "",
+          ),
+          IOSAuthMessages(
+            cancelButton: iosCancelButton,
+            lockOut: iosLockoutMessage,
+          ),
+        ],
+      );
+      return BiometricAuthResult(success: ok, cancelled: !ok);
+    } on PlatformException catch (e) {
+      final unsupported =
+          e.code == auth_error.notAvailable ||
+          e.code == auth_error.notEnrolled ||
+          e.code == auth_error.passcodeNotSet;
+      return BiometricAuthResult(
+        success: false,
+        cancelled: false,
+        unsupported: unsupported,
+        errorCode: e.code,
+      );
+    }
+  }
+}

--- a/yivi_core/lib/src/util/biometric_auth.dart
+++ b/yivi_core/lib/src/util/biometric_auth.dart
@@ -1,6 +1,7 @@
 import "dart:async";
 import "dart:io";
 
+import "package:flutter/foundation.dart";
 import "package:flutter/services.dart";
 import "package:local_auth/error_codes.dart" as auth_error;
 import "package:local_auth/local_auth.dart";
@@ -22,16 +23,33 @@ class BiometricAuthResult {
 }
 
 class BiometricAuth {
-  BiometricAuth({LocalAuthentication? auth})
+  // Test hook: when set, every default `BiometricAuth()` constructor call
+  // returns the factory result. Lets integration tests script biometric
+  // outcomes without touching screens that construct BiometricAuth inline.
+  @visibleForTesting
+  static BiometricAuth Function()? overrideFactory;
+
+  factory BiometricAuth({LocalAuthentication? auth}) {
+    final override = overrideFactory;
+    if (override != null) return override();
+    return BiometricAuth.real(auth: auth);
+  }
+
+  BiometricAuth.real({LocalAuthentication? auth})
     : _auth = auth ?? LocalAuthentication();
 
-  final LocalAuthentication _auth;
+  @visibleForTesting
+  BiometricAuth.forTesting() : _auth = null;
+
+  final LocalAuthentication? _auth;
 
   Future<bool> canAuthenticate() async {
+    final auth = _auth;
+    if (auth == null) return false;
     try {
-      final isSupported = await _auth.isDeviceSupported();
+      final isSupported = await auth.isDeviceSupported();
       if (!isSupported) return false;
-      return _auth.canCheckBiometrics;
+      return auth.canCheckBiometrics;
     } on PlatformException {
       return false;
     }
@@ -44,6 +62,10 @@ class BiometricAuth {
     required String iosCancelButton,
     required String iosLockoutMessage,
   }) async {
+    final auth = _auth;
+    if (auth == null) {
+      return const BiometricAuthResult(success: false, unsupported: true);
+    }
     try {
       // Android maps `localizedReason` to `BiometricPrompt.setDescription`,
       // which renders as a third line under title + subtitle. We already
@@ -54,7 +76,7 @@ class BiometricAuth {
       // On iOS `localizedReason` IS the main prompt text and must be
       // meaningful and non-empty, so we keep it there.
       final localizedReason = Platform.isAndroid ? " " : reason;
-      final ok = await _auth.authenticate(
+      final ok = await auth.authenticate(
         localizedReason: localizedReason,
         options: const AuthenticationOptions(
           stickyAuth: true,

--- a/yivi_core/pubspec.lock
+++ b/yivi_core/pubspec.lock
@@ -621,6 +621,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  local_auth:
+    dependency: "direct main"
+    description:
+      name: local_auth
+      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  local_auth_android:
+    dependency: "direct main"
+    description:
+      name: local_auth_android
+      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.56"
+  local_auth_darwin:
+    dependency: "direct main"
+    description:
+      name: local_auth_darwin
+      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.1"
+  local_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: local_auth_platform_interface
+      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  local_auth_windows:
+    dependency: transitive
+    description:
+      name: local_auth_windows
+      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
   logger:
     dependency: transitive
     description:

--- a/yivi_core/pubspec.lock
+++ b/yivi_core/pubspec.lock
@@ -645,6 +645,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  local_auth:
+    dependency: "direct main"
+    description:
+      name: local_auth
+      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  local_auth_android:
+    dependency: "direct main"
+    description:
+      name: local_auth_android
+      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.56"
+  local_auth_darwin:
+    dependency: "direct main"
+    description:
+      name: local_auth_darwin
+      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.1"
+  local_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: local_auth_platform_interface
+      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  local_auth_windows:
+    dependency: transitive
+    description:
+      name: local_auth_windows
+      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
   logger:
     dependency: transitive
     description:

--- a/yivi_core/pubspec.yaml
+++ b/yivi_core/pubspec.yaml
@@ -60,6 +60,9 @@ dependencies:
       ref: v3.8.0
   mask_text_input_formatter: ^2.9.0
   jailbreak_root_detection: ^1.2.0+1
+  local_auth: ^2.3.0
+  local_auth_android: ^1.0.46
+  local_auth_darwin: ^1.4.2
   # Temporary forks because their original repos are not compatible with new android api's.
   # Should be reverted back to their published version when they're made compatible.
   native_device_orientation:

--- a/yivi_core/pubspec.yaml
+++ b/yivi_core/pubspec.yaml
@@ -61,6 +61,9 @@ dependencies:
       ref: v3.8.0
   mask_text_input_formatter: ^2.9.0
   jailbreak_root_detection: ^1.2.0+1
+  local_auth: ^2.3.0
+  local_auth_android: ^1.0.46
+  local_auth_darwin: ^1.4.2
   # Temporary forks because their original repos are not compatible with new android api's.
   # Should be reverted back to their published version when they're made compatible.
   native_device_orientation:

--- a/yivi_core/test/session_error_test.dart
+++ b/yivi_core/test/session_error_test.dart
@@ -32,13 +32,27 @@ class TestWidget extends StatelessWidget {
   );
 }
 
+/// Mount [widget] and wait for the async FlutterI18nDelegate file loader to
+/// complete. `pumpAndSettle` runs under the test framework's fake clock and
+/// does not drive the real-time IO that `rootBundle.loadString` uses, so the
+/// translation Future never resolves and the home widget never builds. Wrap
+/// the initial pump in `runAsync` so the file load actually runs, then settle.
+Future<void> _pumpWithI18n(WidgetTester tester, Widget widget) async {
+  await tester.runAsync(() async {
+    await tester.pumpWidget(widget);
+    // Give the FileTranslationLoader a chance to read both the active and
+    // fallback locale files before we hand control back to fake time.
+    await Future<void>.delayed(Duration.zero);
+  });
+  await tester.pumpAndSettle();
+}
+
 void main() {
   const errorScreenKey = ValueKey("error_screen");
   testWidgets("errorType = transport", (WidgetTester tester) async {
     final error = SessionError(errorType: "transport", info: "info");
 
-    await tester.pumpWidget(TestWidget(error));
-    await tester.pumpAndSettle();
+    await _pumpWithI18n(tester, TestWidget(error));
 
     expect(find.byKey(const ValueKey("no_internet_screen")), findsOneWidget);
   });
@@ -46,8 +60,7 @@ void main() {
   testWidgets("errorType = pairingRejected", (WidgetTester tester) async {
     final error = SessionError(errorType: "pairingRejected", info: "info");
 
-    await tester.pumpWidget(TestWidget(error));
-    await tester.pumpAndSettle();
+    await _pumpWithI18n(tester, TestWidget(error));
     expect(find.byKey(errorScreenKey), findsOneWidget);
   });
 
@@ -58,8 +71,7 @@ void main() {
       remoteError: RemoteError(errorName: "USER_NOT_FOUND"),
     );
 
-    await tester.pumpWidget(TestWidget(error));
-    await tester.pumpAndSettle();
+    await _pumpWithI18n(tester, TestWidget(error));
     expect(find.byType(BlockedScreen), findsOneWidget);
   });
 
@@ -70,8 +82,7 @@ void main() {
       remoteError: RemoteError(errorName: "SESSION_UNKNOWN"),
     );
 
-    await tester.pumpWidget(TestWidget(error));
-    await tester.pumpAndSettle();
+    await _pumpWithI18n(tester, TestWidget(error));
     expect(find.byKey(errorScreenKey), findsOneWidget);
   });
 
@@ -82,8 +93,7 @@ void main() {
       remoteError: RemoteError(errorName: "UNEXPECTED_REQUEST"),
     );
 
-    await tester.pumpWidget(TestWidget(error));
-    await tester.pumpAndSettle();
+    await _pumpWithI18n(tester, TestWidget(error));
     expect(find.byKey(errorScreenKey), findsOneWidget);
   });
 
@@ -94,8 +104,7 @@ void main() {
       remoteError: RemoteError(errorName: ""),
     );
 
-    await tester.pumpWidget(TestWidget(error));
-    await tester.pumpAndSettle();
+    await _pumpWithI18n(tester, TestWidget(error));
     expect(find.byKey(errorScreenKey), findsOneWidget);
   });
 }

--- a/yivi_fdroid/pubspec.lock
+++ b/yivi_fdroid/pubspec.lock
@@ -486,6 +486,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  local_auth:
+    dependency: transitive
+    description:
+      name: local_auth
+      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  local_auth_android:
+    dependency: transitive
+    description:
+      name: local_auth_android
+      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.56"
+  local_auth_darwin:
+    dependency: transitive
+    description:
+      name: local_auth_darwin
+      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.1"
+  local_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: local_auth_platform_interface
+      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  local_auth_windows:
+    dependency: transitive
+    description:
+      name: local_auth_windows
+      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
   logger:
     dependency: transitive
     description:

--- a/yivi_fdroid/pubspec.lock
+++ b/yivi_fdroid/pubspec.lock
@@ -462,6 +462,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  local_auth:
+    dependency: transitive
+    description:
+      name: local_auth
+      sha256: "434d854cf478f17f12ab29a76a02b3067f86a63a6d6c4eb8fbfdcfe4879c1b7b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.0"
+  local_auth_android:
+    dependency: transitive
+    description:
+      name: local_auth_android
+      sha256: a0bdfcc0607050a26ef5b31d6b4b254581c3d3ce3c1816ab4d4f4a9173e84467
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.56"
+  local_auth_darwin:
+    dependency: transitive
+    description:
+      name: local_auth_darwin
+      sha256: "699873970067a40ef2f2c09b4c72eb1cfef64224ef041b3df9fdc5c4c1f91f49"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.1"
+  local_auth_platform_interface:
+    dependency: transitive
+    description:
+      name: local_auth_platform_interface
+      sha256: f98b8e388588583d3f781f6806e4f4c9f9e189d898d27f0c249b93a1973dd122
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  local_auth_windows:
+    dependency: transitive
+    description:
+      name: local_auth_windows
+      sha256: bc4e66a29b0fdf751aafbec923b5bed7ad6ed3614875d8151afe2578520b2ab5
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.11"
   logger:
     dependency: transitive
     description:


### PR DESCRIPTION
## Summary

Opt-in setting that lets users unlock the Yivi app with platform-native biometrics (Face ID / Touch ID / fingerprint) instead of the PIN. Available during enrollment (right after pin confirmation) and via Settings → "Unlock with biometrics". Default: off — existing users see no change until they explicitly enable it.

PIN remains the **only** authentication mechanism for any operation that involves the keyshare server (issuance, disclosure, `requireAuthBeforeSession` flows). The biometric path *only* flips the local Dart `_lockedSubject` flag; it never dispatches an `AuthenticateEvent` to irmago.

## How it works

| Surface | Mechanism |
|---|---|
| `/pin` (app-open lock screen) | Auto-prompts biometric on mount when enabled; fingerprint key under the 7 lets the user retry. Falls back to manual PIN keypad on cancel/failure. |
| `/modal_pin` (pre-session auth) | **Unchanged** — always manual PIN. `allowBiometricBypass: false`. |
| `SessionPinEntryScreen` (mid-session keyshare auth) | **Unchanged** — always manual PIN. |
| Enrollment | New optional step after pin confirm. Skipped silently on devices that report no biometric capability. |
| Settings | Toggle visible only on capable devices. Enabling requires a one-off biometric prompt up front. |

The OS prompt uses `biometricOnly: true`, so the OS will never offer its device passcode as fallback — fewer "which PIN do I enter" moments for the user.

## Side effects and operational impact

### Keyshare server: "login" event becomes effectively optional per app launch
- Today, every app open dispatches `AuthenticateEvent(pin, schemeId)` which performs a keyshare login round-trip. Biometric users skip this entirely.
- The keyshare login still happens — just deferred to the first session that actually needs it. At that point `SessionPinEntryScreen` collects the PIN and forwards it to irmago, which performs the keyshare auth.
- **If the keyshare server is used for per-launch metrics, audit logging, or "active user" heuristics, those counts will drop** for opted-in users. Worth double-checking server-side dashboards before rollout.
- A biometric-only user who never starts a session (just browses their credentials in the app) will produce **zero** keyshare login traffic across that session.

### Inactivity / auto-lock
- The existing 5-minute background-resume auto-lock in `app.dart` (`pause+inactive` → `resume` → `repo.lock()`) **still works**. Biometric just makes re-unlocking faster.
- There is no time-based auto-lock while the app is in foreground — this PR does not change that.
- If you later want a stricter inactivity policy (e.g., always lock on backgrounding), biometric makes that ergonomically affordable; without biometric the friction would be high.

### Wrong-PIN attempt counter & keyshare blocking
- The keyshare server blocks users after N wrong PINs. With biometric unlock, **fewer wrong-PIN events reach the server** because the entire app-open keypad path is bypassed.
- Net effect: smaller online brute-force surface at the cost of fewer signals for "user is fumbling their PIN."
- Wrong-PIN events from session pin entries are unchanged.

### Wider Android change: `MainActivity` now extends `FlutterFragmentActivity`
- Required by `local_auth_android` (BiometricPrompt is shown as a fragment).
- This is a **host-Activity change** that could in theory affect other native plugins. We scanned and didn't see issues, but smoke-test all native flows (NFC, camera, deeplinks, share_plus, file pickers) before release.

### New platform permissions
- Android: `<uses-permission android:name="android.permission.USE_BIOMETRIC" />`
- iOS: `NSFaceIDUsageDescription` ("Use Face ID to open Yivi.") — Apple reviews this string; update if marketing/legal prefers different wording before submission.

### Device-theft threat model
- PIN-only: thief needs the PIN.
- Biometric-enabled: thief needs the enrolled biometric (face/finger). Coerced-finger attacks are slightly easier than coerced-PIN-entry in adversarial scenarios. Documented for awareness; this is the standard trade-off any biometric unlock makes.

### Biometric data privacy (called out to users in enrollment text)
- `local_auth` returns a boolean; the OS never exposes biometric templates to the app.
- We store **nothing** PIN-related or biometric-related. The only thing persisted is a single boolean preference (`preference.biometric_unlock_enabled`).
- Biometric data is never sent to Yivi, issuers, or relying parties — only used by the OS to gate the in-app unlock.

### Migration / rollback
- Default `biometricUnlockEnabled = false`. Existing installs behave identically to today.
- Toggle off in Settings at any time. Disabling does not require biometric confirmation.
- The setting is cleared by `ClearAllDataEvent` along with the rest of the preferences.

### UX details
- Fingerprint icon sits in the bottom-left slot of the keypad (under the 7) and looks like a regular keypad key.
- Failed/cancelled biometric prompt leaves the keypad fully usable; user can retry biometric via the key.
- On Android, the BiometricPrompt's "Verify identity" subtitle is hidden (empty `biometricHint`); the description row carries a single-space placeholder because `local_auth_android` asserts the `localizedReason` is non-empty — there will be a thin blank row beneath the title. Fully suppressing it requires forking the plugin.

## Known limitations
- `local_auth_android` blocks an empty `localizedReason`, so Android shows a slim empty description row beneath the title. Cosmetic.
- Some Android OEMs customize the BiometricPrompt rendering; the empty subtitle may behave differently on a few devices. Worth a spot check across Samsung / Xiaomi / Pixel.
- We do **not** currently re-verify biometric capability after enrollment. If the user disables biometrics in OS settings and reopens Yivi, our code silently falls back to the PIN keypad — but the Settings toggle will stay on until they touch it.

## Files of note
- New: `yivi_core/lib/src/util/biometric_auth.dart`, `yivi_core/lib/src/screens/enrollment/biometric_setup/biometric_setup_screen.dart`
- `IrmaRepository.unlockWithBiometrics()` — the deliberate side-door that bypasses irmago. Comments at the call site explain why.
- `PinScreen.allowBiometricBypass` flag distinguishes app-open `/pin` (allowed) from `/modal_pin` (never).
- Enrollment bloc gains an `EnrollmentBiometricSetup` state, gated on `BiometricAuth.canAuthenticate()`.

## Incidental test fix

Adding the biometric translations pushed the combined `nl.json + en.json` payload over ~98 KB, which surfaced a latent race in `session_error_test.dart`: the test mounts a `MaterialApp` with `FlutterI18nDelegate` whose `FileTranslationLoader` reads JSON via `rootBundle.loadString`, but `pumpAndSettle` runs under the test framework's fake clock and doesn't drive that real-time IO. As long as the bundle was small enough to settle within the first fake-clock tick the test passed by luck; once the file grew, the translation Future hadn't resolved when `pumpAndSettle` returned, the `MaterialApp` was still in its pre-localized state, and `find.byKey` returned zero widgets for every test.

Fixed in this PR rather than worked around: added a `_pumpWithI18n` helper that wraps the initial `pumpWidget` in `tester.runAsync` so the file load runs against real time, then hands control back to `pumpAndSettle` to flush the rebuild. Every `testWidgets` block now goes through that helper.

```dart
Future<void> _pumpWithI18n(WidgetTester tester, Widget widget) async {
  await tester.runAsync(() async {
    await tester.pumpWidget(widget);
    await Future<void>.delayed(Duration.zero);
  });
  await tester.pumpAndSettle();
}
```

Net effect: the test is no longer size-sensitive, and future PRs can grow the locale bundles without re-triggering the same failure.
