### PR TITLE
Add spinner after each session user interaction

### DIFF
--- a/yivi_app/integration_test/irma_binding.dart
+++ b/yivi_app/integration_test/irma_binding.dart
@@ -134,7 +134,7 @@ Nu1bRk5gLEwmR5+V6MSFQWyWBkwacOt8
 
   Future<void> tearDown() async {
     // Dismiss all active sessions to prevent them from bleeding into the next test.
-    await _repository?.dismissAllActiveSessions();
+    _repository?.dismissAllActiveSessions();
 
     // Make sure there is a listener for the bridge events.
     final dataClearedFuture = _expectBridgeEventGuarded<EnrollmentStatusEvent>(

--- a/yivi_app/lib/credential_card_previews.dart
+++ b/yivi_app/lib/credential_card_previews.dart
@@ -1,0 +1,742 @@
+// Widget previews for [YiviCredentialCard].
+//
+// Run with: `flutter widget-preview start` from `yivi_app/`.
+//
+// Most scenarios here focus on the attribute-list rendering rules — in
+// particular, how the card behaves for arrays / nested objects with and
+// without an explicit header attribute, and how `effectiveDisplayName` falls
+// back when the backend did not supply a `displayName`.
+
+import "package:flutter/material.dart";
+import "package:flutter/widget_previews.dart";
+// ignore_for_file: depend_on_referenced_packages, implementation_imports
+import "package:flutter_i18n/flutter_i18n.dart";
+import "package:flutter_i18n/loaders/decoders/json_decode_strategy.dart";
+import "package:flutter_localizations/flutter_localizations.dart";
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:google_fonts/google_fonts.dart";
+
+import "package:yivi_core/src/models/log_entry.dart";
+import "package:yivi_core/src/models/schemaless/schemaless_events.dart";
+import "package:yivi_core/src/models/translated_value.dart";
+import "package:yivi_core/src/theme/theme.dart";
+import "package:yivi_core/src/widgets/credential_card/models/credential_card_status.dart";
+import "package:yivi_core/src/widgets/credential_card/yivi_credential_card.dart";
+import "package:yivi_core/src/widgets/irma_card.dart";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Preview scaffolding
+// ─────────────────────────────────────────────────────────────────────────────
+
+/// Loads the real `yivi_core` translations from the asset bundle.
+///
+/// [FileTranslationLoader] probes every supported extension in parallel
+/// (`.json`, `.yaml`, `.xml`, `.toml`); without `decodeStrategies` you get
+/// three guaranteed 404s per language load. Restricting to JSON keeps the
+/// console clean.
+FlutterI18nDelegate _buildI18nDelegate() => FlutterI18nDelegate(
+  translationLoader: FileTranslationLoader(
+    basePath: "packages/yivi_core/assets/locales",
+    fallbackFile: "en",
+    forcedLocale: const Locale("en", "US"),
+    decodeStrategies: [JsonDecodeStrategy()],
+  ),
+);
+
+/// Default canvas size for every preview. Picking one fixed size makes the
+/// gallery tile previews side-by-side instead of stretching to fit, which is
+/// what makes cross-preview comparison useful.
+const yiviCardPreviewSize = Size(380, 640);
+
+/// A single Riverpod container shared by every preview.
+final _previewProviderContainer = ProviderContainer();
+
+/// Loads the `yivi_core` fonts at runtime via [FontLoader]. The widget-preview
+/// tool generates a scaffold project that registers yivi_core's fonts only
+/// under the package-prefixed names (`packages/yivi_core/Alexandria` etc.),
+/// but `IrmaTheme` uses the unqualified family names. We register them under
+/// the unqualified names here.
+///
+/// The font files are accessible at runtime via these `packages/yivi_core/...`
+/// paths because yivi_core's pubspec declares `fonts/alexandria/`,
+/// `fonts/open-sans/`, and `fonts/irma-icons/` in its `assets:` section.
+/// Result of the font registration pass. Reported on-screen so we don't have
+/// to chase terminal output.
+class _FontLoadReport {
+  final List<String> registered = [];
+  final List<String> failed = [];
+}
+
+/// Loads Alexandria + Open Sans from Google Fonts (CDN) at runtime. Internally,
+/// `google_fonts` calls `FontLoader` with `Alexandria` / `Open Sans` as the
+/// family names, which is exactly what `IrmaTheme` looks up. The bundled-font
+/// path under `flutter widget-preview` doesn't reliably resolve, so we go via
+/// the CDN here.
+///
+/// IrmaIcons is bundled-only — no Google Fonts equivalent — so icon glyphs in
+/// the preview will fall back to system rendering. None of the credential-card
+/// previews actually use IrmaIcons glyphs, so this is fine.
+Future<_FontLoadReport> _loadYiviFonts() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  GoogleFonts.config.allowRuntimeFetching = true;
+  final report = _FontLoadReport();
+  final loads = <String, Future<void>>{
+    "Alexandria": GoogleFonts.pendingFonts([GoogleFonts.alexandria()]),
+    "Open Sans": GoogleFonts.pendingFonts([GoogleFonts.openSans()]),
+  };
+  for (final entry in loads.entries) {
+    try {
+      await entry.value;
+      report.registered.add(entry.key);
+    } catch (e) {
+      report.failed.add("${entry.key}: $e");
+    }
+  }
+  // Force any text widgets that were already laid out to relayout with the
+  // newly-registered fonts.
+  PaintingBinding.instance.handleSystemMessage(<String, Object?>{
+    "type": "fontsChange",
+  });
+  return report;
+}
+
+final Future<_FontLoadReport> _fontsReady = _loadYiviFonts();
+
+/// Riverpod 3.x (both 3.2 and 3.3) schedules an unconditional post-frame
+/// `setState({})` from `_UncontrolledProviderScopeState.build` with no
+/// `mounted` guard. The preview runner mounts/unmounts previews as the user
+/// navigates, so the post-frame fires after dispose and trips a
+/// `setState() called after dispose()` assertion. The previews render fine —
+/// the noise just floods the console. Filter that one specific assertion at
+/// startup and forward everything else.
+final _suppressRiverpodDisposeNoise = () {
+  final original = FlutterError.onError;
+  FlutterError.onError = (details) {
+    final msg = details.exception.toString();
+    if (msg.contains("setState() called after dispose()") &&
+        msg.contains("_UncontrolledProviderScopeState")) {
+      return;
+    }
+    (original ?? FlutterError.presentError)(details);
+  };
+  return true;
+}();
+
+/// Wraps a preview in the providers/theme/i18n stack the card needs. Must be
+/// a public top-level function so the preview annotation can reference it.
+Widget yiviCardPreviewWrapper(Widget child) {
+  // Touch the lazy initializer so the error filter installs on first use.
+  // ignore: unnecessary_statements
+  _suppressRiverpodDisposeNoise;
+  return UncontrolledProviderScope(
+    container: _previewProviderContainer,
+    child: MaterialApp(
+      debugShowCheckedModeBanner: false,
+      localizationsDelegates: [
+        _buildI18nDelegate(),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: const [Locale("en", "US")],
+      home: IrmaTheme(
+        builder: (context) {
+          final theme = IrmaTheme.of(context);
+          return Scaffold(
+            backgroundColor: theme.light,
+            body: SafeArea(
+              child: SingleChildScrollView(
+                padding: EdgeInsets.all(theme.defaultSpacing),
+                // Hold rendering until the yivi fonts are registered so the
+                // card doesn't briefly flash in the system font.
+                child: FutureBuilder<_FontLoadReport>(
+                  future: _fontsReady,
+                  builder: (context, snap) {
+                    if (snap.connectionState != ConnectionState.done) {
+                      return const SizedBox.shrink();
+                    }
+                    final report = snap.data;
+                    return Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        if (report != null && report.failed.isNotEmpty)
+                          Padding(
+                            padding: const EdgeInsets.only(bottom: 8),
+                            child: Text(
+                              "Font load FAILED: ${report.failed.join(' | ')}",
+                              style: const TextStyle(
+                                fontSize: 11,
+                                color: Color(0xFFB00020),
+                              ),
+                            ),
+                          ),
+                        child,
+                      ],
+                    );
+                  },
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    ),
+  );
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixture helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+TrustedParty _demoIssuer() => TrustedParty(
+  id: "irma-demo.MijnOverheid",
+  name: TranslatedValue({"en": "Demo MijnOverheid"}),
+  url: null,
+  parent: null,
+  verified: true,
+);
+
+/// Builds an `Attribute` with a value. Pass `displayName: ""` to exercise the
+/// `effectiveDisplayName` fallback path.
+Attribute _leaf({
+  required List<dynamic> claimPath,
+  String displayName = "",
+  String? stringValue,
+  bool? boolValue,
+  int? intValue,
+}) {
+  final dn = displayName.isEmpty
+      ? const TranslatedValue.empty()
+      : TranslatedValue({"en": displayName});
+  AttributeValue? value;
+  if (stringValue != null) {
+    value = AttributeValue(type: AttributeType.string, string: stringValue);
+  } else if (boolValue != null) {
+    value = AttributeValue(type: AttributeType.boolean, boolValue: boolValue);
+  } else if (intValue != null) {
+    value = AttributeValue(type: AttributeType.integer, intValue: intValue);
+  }
+  return Attribute(claimPath: claimPath, displayName: dn, value: value);
+}
+
+/// Builds a *header* attribute (value == null). Headers anchor the
+/// labels for groups and arrays in the attribute tree.
+Attribute _header({required List<dynamic> claimPath, String displayName = ""}) {
+  final dn = displayName.isEmpty
+      ? const TranslatedValue.empty()
+      : TranslatedValue({"en": displayName});
+  return Attribute(claimPath: claimPath, displayName: dn);
+}
+
+YiviCredentialCard _card({
+  required List<Attribute> attributes,
+  String name = "Demo Credential",
+  IrmaCardStyle style = IrmaCardStyle.normal,
+  bool revoked = false,
+  int? expiryDateUnix,
+  Map<CredentialFormat, int?> batchCounts = const {},
+  TranslatedValue? issueUrl,
+  bool hideFooter = true,
+}) {
+  return YiviCredentialCard(
+    credentialName: TranslatedValue({"en": name}),
+    issuerName: _demoIssuer().name,
+    attributes: attributes,
+    status: CredentialCardStatus(
+      revoked: revoked,
+      expiryDateUnix: expiryDateUnix,
+      batchInstanceCountsRemaining: batchCounts,
+      credentialId: "irma-demo.MijnOverheid.root",
+      issueUrl: issueUrl,
+    ),
+    compact: false,
+    style: style,
+    hideFooter: hideFooter,
+  );
+}
+
+// Returns a unix timestamp `days` days from now. Computed at call time so the
+// previews stay accurate as time passes.
+int _unixDaysFromNow(int days) =>
+    DateTime.now().add(Duration(days: days)).millisecondsSinceEpoch ~/ 1000;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group: Basic attributes
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Preview(
+  group: "Basics",
+  name: "Simple attributes",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewSimpleAttributes() => _card(
+  attributes: [
+    _leaf(
+      claimPath: const ["bsn"],
+      displayName: "BSN",
+      stringValue: "999999990",
+    ),
+    _leaf(
+      claimPath: const ["firstname"],
+      displayName: "First name",
+      stringValue: "Willeke",
+    ),
+    _leaf(
+      claimPath: const ["familyname"],
+      displayName: "Family name",
+      stringValue: "Bruijn",
+    ),
+  ],
+);
+
+@Preview(
+  group: "Basics",
+  name: "Boolean Yes/No",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewBooleanAttributes() => _card(
+  attributes: [
+    _leaf(claimPath: const ["over18"], displayName: "Over 18", boolValue: true),
+    _leaf(
+      claimPath: const ["over65"],
+      displayName: "Over 65",
+      boolValue: false,
+    ),
+  ],
+);
+
+@Preview(
+  group: "Basics",
+  name: "Mixed types",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewMixedTypes() => _card(
+  attributes: [
+    _leaf(
+      claimPath: const ["name"],
+      displayName: "Name",
+      stringValue: "Willeke",
+    ),
+    _leaf(claimPath: const ["age"], displayName: "Age", intValue: 42),
+    _leaf(claimPath: const ["over18"], displayName: "Over 18", boolValue: true),
+  ],
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group: effectiveDisplayName fallback
+//
+// These exercise the new `effectiveDisplayName` getter introduced in the
+// PR. Compare these against the "Basics" group to see how missing
+// `displayName` labels get filled in from `claimPath`.
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Preview(
+  group: "Fallback",
+  name: "Top-level: no displayName",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewTopLevelNoDisplayName() => _card(
+  attributes: [
+    _leaf(claimPath: const ["firstname"], stringValue: "Willeke"),
+    _leaf(claimPath: const ["familyname"], stringValue: "Bruijn"),
+  ],
+);
+
+@Preview(
+  group: "Fallback",
+  name: "Top-level: all-int claim path",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewAllIntClaimPath() => _card(
+  attributes: [
+    // Last-resort fallback: `claimPath.join(".")` → "0".
+    _leaf(claimPath: const [0], stringValue: "weird"),
+  ],
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group: Primitive arrays — with vs. without explicit header attribute
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Preview(
+  group: "Prim arrays",
+  name: "WITH explicit header",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewPrimArrayWithHeader() => _card(
+  attributes: [
+    _header(claimPath: const ["tags"], displayName: "Tags"),
+    _leaf(claimPath: const ["tags", 0], stringValue: "red"),
+    _leaf(claimPath: const ["tags", 1], stringValue: "green"),
+    _leaf(claimPath: const ["tags", 2], stringValue: "blue"),
+  ],
+);
+
+@Preview(
+  group: "Prim arrays",
+  name: "WITHOUT explicit header",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewPrimArrayWithoutHeader() => _card(
+  attributes: [
+    // No `["tags"]` header attribute. Pre-PR this rendered with an empty
+    // label (effectively no header); after the PR the label falls back to
+    // "tags" from the claim path.
+    _leaf(claimPath: const ["tags", 0], stringValue: "red"),
+    _leaf(claimPath: const ["tags", 1], stringValue: "green"),
+    _leaf(claimPath: const ["tags", 2], stringValue: "blue"),
+  ],
+);
+
+@Preview(
+  group: "Prim arrays",
+  name: "WITH header, empty displayName",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewPrimArrayHeaderEmptyDisplayName() => _card(
+  attributes: [
+    // Header is present but its `displayName` is empty. After the PR this
+    // still falls back to "tags" because the header itself uses
+    // `effectiveDisplayName`.
+    _header(claimPath: const ["tags"]),
+    _leaf(claimPath: const ["tags", 0], stringValue: "red"),
+    _leaf(claimPath: const ["tags", 1], stringValue: "green"),
+  ],
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group: Object arrays — with vs. without explicit header attribute
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Preview(
+  group: "Object arrays",
+  name: "WITH explicit header",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewObjectArrayWithHeader() => _card(
+  attributes: [
+    _header(claimPath: const ["addresses"], displayName: "Addresses"),
+    _leaf(
+      claimPath: const ["addresses", 0, "street"],
+      displayName: "Street",
+      stringValue: "Meander",
+    ),
+    _leaf(
+      claimPath: const ["addresses", 0, "city"],
+      displayName: "City",
+      stringValue: "Arnhem",
+    ),
+    _leaf(
+      claimPath: const ["addresses", 1, "street"],
+      displayName: "Street",
+      stringValue: "Hoofdweg",
+    ),
+    _leaf(
+      claimPath: const ["addresses", 1, "city"],
+      displayName: "City",
+      stringValue: "Amsterdam",
+    ),
+  ],
+);
+
+@Preview(
+  group: "Object arrays",
+  name: "WITHOUT explicit header",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewObjectArrayWithoutHeader() => _card(
+  attributes: [
+    // No `["addresses"]` header. The per-item eyebrow falls back to "ITEM"
+    // because `parentHeader` is null. Compare with the previous preview.
+    _leaf(
+      claimPath: const ["addresses", 0, "street"],
+      displayName: "Street",
+      stringValue: "Meander",
+    ),
+    _leaf(
+      claimPath: const ["addresses", 0, "city"],
+      displayName: "City",
+      stringValue: "Arnhem",
+    ),
+    _leaf(
+      claimPath: const ["addresses", 1, "street"],
+      displayName: "Street",
+      stringValue: "Hoofdweg",
+    ),
+    _leaf(
+      claimPath: const ["addresses", 1, "city"],
+      displayName: "City",
+      stringValue: "Amsterdam",
+    ),
+  ],
+);
+
+@Preview(
+  group: "Object arrays",
+  name: "Child leaves WITHOUT displayName",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewObjectArrayChildrenNoDisplayName() => _card(
+  attributes: [
+    _header(claimPath: const ["addresses"], displayName: "Addresses"),
+    // Leaves have empty displayName — after the PR they show "street" /
+    // "city" derived from the claim path. Pre-PR they rendered blank.
+    _leaf(claimPath: const ["addresses", 0, "street"], stringValue: "Meander"),
+    _leaf(claimPath: const ["addresses", 0, "city"], stringValue: "Arnhem"),
+  ],
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group: Nested objects (no array indices)
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Preview(
+  group: "Nested objects",
+  name: "WITH explicit header",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewNestedObjectWithHeader() => _card(
+  attributes: [
+    _header(claimPath: const ["address"], displayName: "Address"),
+    _leaf(
+      claimPath: const ["address", "street"],
+      displayName: "Street",
+      stringValue: "Meander",
+    ),
+    _leaf(
+      claimPath: const ["address", "city"],
+      displayName: "City",
+      stringValue: "Arnhem",
+    ),
+  ],
+);
+
+@Preview(
+  group: "Nested objects",
+  name: "WITHOUT explicit header",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewNestedObjectWithoutHeader() => _card(
+  attributes: [
+    // No `["address"]` header. With no header attribute the tree builder
+    // doesn't synthesise a group — the leaves render side-by-side.
+    _leaf(
+      claimPath: const ["address", "street"],
+      displayName: "Street",
+      stringValue: "Meander",
+    ),
+    _leaf(
+      claimPath: const ["address", "city"],
+      displayName: "City",
+      stringValue: "Arnhem",
+    ),
+  ],
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group: Card visual states
+// ─────────────────────────────────────────────────────────────────────────────
+
+@Preview(
+  group: "States",
+  name: "Normal",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewStateNormal() => _card(
+  attributes: [
+    _leaf(
+      claimPath: const ["bsn"],
+      displayName: "BSN",
+      stringValue: "999999990",
+    ),
+  ],
+);
+
+@Preview(
+  group: "States",
+  name: "Highlighted",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewStateHighlighted() => _card(
+  attributes: [
+    _leaf(
+      claimPath: const ["bsn"],
+      displayName: "BSN",
+      stringValue: "999999990",
+    ),
+  ],
+  style: IrmaCardStyle.highlighted,
+);
+
+@Preview(
+  group: "States",
+  name: "Revoked",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewStateRevoked() => _card(
+  attributes: [
+    _leaf(
+      claimPath: const ["bsn"],
+      displayName: "BSN",
+      stringValue: "999999990",
+    ),
+  ],
+  revoked: true,
+);
+
+@Preview(
+  group: "States",
+  name: "Expired",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewStateExpired() => _card(
+  attributes: [
+    _leaf(
+      claimPath: const ["bsn"],
+      displayName: "BSN",
+      stringValue: "999999990",
+    ),
+  ],
+  // ~Jan 2024 — well in the past.
+  expiryDateUnix: 1704067200,
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Group: Card footer
+//
+// The footer shows two cells: "Valid until <date>" and "Sharable" (with a
+// count or "unlimited"). The text colour switches to warning / error as the
+// time- and instance-expire states tip over the thresholds.
+// ─────────────────────────────────────────────────────────────────────────────
+
+List<Attribute> _footerAttrs() => [
+  _leaf(claimPath: const ["bsn"], displayName: "BSN", stringValue: "999999990"),
+];
+
+@Preview(
+  group: "Footer",
+  name: "Valid, unlimited sharable",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewFooterValidUnlimited() => _card(
+  attributes: _footerAttrs(),
+  expiryDateUnix: _unixDaysFromNow(365),
+  // Empty batchCounts → instanceCount stays null → "Sharable unlimited".
+  batchCounts: const {},
+  hideFooter: false,
+);
+
+@Preview(
+  group: "Footer",
+  name: "Valid, N sharable",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewFooterValidCount() => _card(
+  attributes: _footerAttrs(),
+  expiryDateUnix: _unixDaysFromNow(365),
+  batchCounts: const {CredentialFormat.idemix: 42},
+  hideFooter: false,
+);
+
+@Preview(
+  group: "Footer",
+  name: "Valid, low sharable (warning)",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewFooterLowCount() => _card(
+  attributes: _footerAttrs(),
+  expiryDateUnix: _unixDaysFromNow(365),
+  // Default threshold is 5 → 3 is "almostExpired" → warning colour.
+  batchCounts: const {CredentialFormat.idemix: 3},
+  hideFooter: false,
+);
+
+@Preview(
+  group: "Footer",
+  name: "Valid, zero sharable (expired count)",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewFooterZeroCount() => _card(
+  attributes: _footerAttrs(),
+  expiryDateUnix: _unixDaysFromNow(365),
+  // instanceCount <= 0 → expired → card flips to danger style.
+  batchCounts: const {CredentialFormat.idemix: 0},
+  hideFooter: false,
+);
+
+@Preview(
+  group: "Footer",
+  name: "Expiring soon (≤ 7 days)",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewFooterExpiringSoon() => _card(
+  attributes: _footerAttrs(),
+  expiryDateUnix: _unixDaysFromNow(3),
+  batchCounts: const {CredentialFormat.idemix: 42},
+  hideFooter: false,
+);
+
+@Preview(
+  group: "Footer",
+  name: "Expired date",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewFooterExpiredDate() => _card(
+  attributes: _footerAttrs(),
+  expiryDateUnix: _unixDaysFromNow(-30),
+  batchCounts: const {CredentialFormat.idemix: 42},
+  hideFooter: false,
+);
+
+@Preview(
+  group: "Footer",
+  name: "Expiring soon, reobtain button",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewFooterReobtainButton() => _card(
+  attributes: _footerAttrs(),
+  expiryDateUnix: _unixDaysFromNow(3),
+  batchCounts: const {CredentialFormat.idemix: 42},
+  // Adding a non-empty issueUrl flips `showReobtain` on once the credential
+  // is expiring/expired/revoked.
+  issueUrl: TranslatedValue({"en": "https://example.invalid/reobtain"}),
+  hideFooter: false,
+);
+
+@Preview(
+  group: "Footer",
+  name: "Worst case: expired + zero count + reobtain",
+  wrapper: yiviCardPreviewWrapper,
+  size: yiviCardPreviewSize,
+)
+Widget previewFooterWorstCase() => _card(
+  attributes: _footerAttrs(),
+  expiryDateUnix: _unixDaysFromNow(-30),
+  batchCounts: const {CredentialFormat.idemix: 0},
+  issueUrl: TranslatedValue({"en": "https://example.invalid/reobtain"}),
+  hideFooter: false,
+);

--- a/yivi_app/pubspec.lock
+++ b/yivi_app/pubspec.lock
@@ -360,6 +360,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "16.3.0"
+  google_fonts:
+    dependency: "direct main"
+    description:
+      name: google_fonts
+      sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.1.0"
   google_mlkit_commons:
     dependency: "direct main"
     description:

--- a/yivi_app/pubspec.lock
+++ b/yivi_app/pubspec.lock
@@ -361,7 +361,7 @@ packages:
     source: hosted
     version: "16.3.0"
   google_fonts:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: google_fonts
       sha256: "4e9391085e524954a51e3625b7c9c7e9851dc3f376603208bb45c24b9a66255d"

--- a/yivi_app/pubspec.yaml
+++ b/yivi_app/pubspec.yaml
@@ -22,6 +22,11 @@ dependencies:
   camera: ^0.10.0+4
   smart_auth: ^3.2.0
   pinput: ^6.0.1
+  # Used only by `lib/credential_card_previews.dart` to pre-load Alexandria /
+  # Open Sans for widget previews. Loaded at runtime from Google's CDN so the
+  # previews don't depend on bundled-font asset resolution, which is flaky
+  # under `flutter widget-preview`.
+  google_fonts: ^8.1.0
 
 dev_dependencies:
   integration_test:

--- a/yivi_app/pubspec.yaml
+++ b/yivi_app/pubspec.yaml
@@ -22,11 +22,6 @@ dependencies:
   camera: ^0.10.0+4
   smart_auth: ^3.2.0
   pinput: ^6.0.1
-  # Used only by `lib/credential_card_previews.dart` to pre-load Alexandria /
-  # Open Sans for widget previews. Loaded at runtime from Google's CDN so the
-  # previews don't depend on bundled-font asset resolution, which is flaky
-  # under `flutter widget-preview`.
-  google_fonts: ^8.1.0
 
 dev_dependencies:
   integration_test:
@@ -34,6 +29,12 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
+
+  # Used only by `lib/credential_card_previews.dart` to pre-load Alexandria /
+  # Open Sans for widget previews. Loaded at runtime from Google's CDN so the
+  # previews don't depend on bundled-font asset resolution, which is flaky
+  # under `flutter widget-preview`.
+  google_fonts: ^8.1.0
 
   # the following packages are required by the integration tests
   vcmrtd:

--- a/yivi_core/go.mod
+++ b/yivi_core/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.7
 require (
 	github.com/go-errors/errors v1.4.2
 	github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750
-	github.com/privacybydesign/irmago v0.19.3-0.20260526103742-5e6381eb4b03
+	github.com/privacybydesign/irmago v0.19.3-0.20260528130631-968ee1dcc4b2
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/mobile v0.0.0-20260120165949-40bd9ace6ce4
 )

--- a/yivi_core/go.sum
+++ b/yivi_core/go.sum
@@ -221,8 +221,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750 h1:3RuYOQTlArQ6Uw2TgySusmZGluP+18WdQL56YSfkM3Q=
 github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750/go.mod h1:QZI8hX8Ff2GfZ7UJuxyWw3nAGgt2s5+U4hxY6rmwQvs=
-github.com/privacybydesign/irmago v0.19.3-0.20260526103742-5e6381eb4b03 h1:CmjXLIlE/CcJ1KzncK3yEsria9v2tRf44DL2axkDm3g=
-github.com/privacybydesign/irmago v0.19.3-0.20260526103742-5e6381eb4b03/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
+github.com/privacybydesign/irmago v0.19.3-0.20260528130631-968ee1dcc4b2 h1:d7qLxo4nfhdKYvoUyMdHu/qJuwxwLltmZAaiZ19077A=
+github.com/privacybydesign/irmago v0.19.3-0.20260528130631-968ee1dcc4b2/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/yivi_core/irmagobridge/event_handler.go
+++ b/yivi_core/irmagobridge/event_handler.go
@@ -95,7 +95,7 @@ func (ah *eventHandler) changePin(event *changePinEvent) (err error) {
 
 // Start a new IRMA session
 func (ah *eventHandler) newSession(event *newSessionEvent) (err error) {
-	yiviClient.NewSession(string(event.Request))
+	yiviClient.NewSession(event.SessionId, string(event.Request))
 	return nil
 }
 

--- a/yivi_core/irmagobridge/events.go
+++ b/yivi_core/irmagobridge/events.go
@@ -30,7 +30,8 @@ type changePinEvent struct {
 }
 
 type newSessionEvent struct {
-	Request json.RawMessage `json:"request"`
+	SessionId int             `json:"session_id"`
+	Request   json.RawMessage `json:"request"`
 }
 
 type sessionUserInteractionEvent struct {

--- a/yivi_core/lib/src/data/irma_repository.dart
+++ b/yivi_core/lib/src/data/irma_repository.dart
@@ -507,6 +507,10 @@ class IrmaRepository {
     return _sessionRepository.newSessionIds;
   }
 
+  // Resets to 0 on Flutter hot-restart while Go still holds prior ids.
+  // `sessionManager.NewSession` evicts the old entry but its goroutines may
+  // linger until they observe the eviction. Dev-only nuisance, not a
+  // production concern (production app starts from a clean Go state too).
   int _nextSessionId = 0;
 
   /// Allocates a session id for an outgoing [NewSessionEvent]. Dart owns id
@@ -514,7 +518,7 @@ class IrmaRepository {
   /// emitted the first session state.
   int allocateSessionId() => ++_nextSessionId;
 
-  Future<bool> hasActiveSessions({int? excludeSessionId}) {
+  bool hasActiveSessions({int? excludeSessionId}) {
     return _sessionRepository.hasActiveSessions(
       excludeSessionId: excludeSessionId,
     );

--- a/yivi_core/lib/src/data/irma_repository.dart
+++ b/yivi_core/lib/src/data/irma_repository.dart
@@ -500,6 +500,13 @@ class IrmaRepository {
     return _sessionRepository.newSessionIds;
   }
 
+  int _nextSessionId = 0;
+
+  /// Allocates a session id for an outgoing [NewSessionEvent]. Dart owns id
+  /// allocation so [SessionScreen] can be pushed synchronously, before Go has
+  /// emitted the first session state.
+  int allocateSessionId() => ++_nextSessionId;
+
   Future<bool> hasActiveSessions({int? excludeSessionId}) {
     return _sessionRepository.hasActiveSessions(
       excludeSessionId: excludeSessionId,

--- a/yivi_core/lib/src/data/irma_repository.dart
+++ b/yivi_core/lib/src/data/irma_repository.dart
@@ -498,6 +498,13 @@ class IrmaRepository {
     return _sessionRepository.isAwaitingInteraction(sessionId);
   }
 
+  /// Synchronous companion to [isSessionAwaitingInteraction]. Useful in the
+  /// first build of a freshly-mounted screen, before the stream provider has
+  /// delivered its seed value.
+  bool isSessionAwaitingInteractionNow(int sessionId) {
+    return _sessionRepository.isAwaitingInteractionNow(sessionId);
+  }
+
   Stream<SessionState> getSessionStateByOpenID4VCIState(String sessionState) {
     return _sessionRepository.getSessionStateByOpenID4VCIState(sessionState);
   }
@@ -525,8 +532,8 @@ class IrmaRepository {
   }
 
   /// Dismisses all sessions that are currently in the requestPermission state.
-  Future<void> dismissAllActiveSessions() async {
-    final activeSessionIds = await _sessionRepository.getActiveSessionIds();
+  void dismissAllActiveSessions() {
+    final activeSessionIds = _sessionRepository.getActiveSessionIds();
     for (final sessionId in activeSessionIds) {
       bridgedDispatch(
         SessionUserInteractionEvent.dismiss(sessionId: sessionId),

--- a/yivi_core/lib/src/data/irma_repository.dart
+++ b/yivi_core/lib/src/data/irma_repository.dart
@@ -491,6 +491,13 @@ class IrmaRepository {
     return _sessionRepository.getSessionState(sessionId);
   }
 
+  /// Whether [sessionId] has a user interaction dispatched to Go that's still
+  /// waiting on a response state event. Cleared automatically when the next
+  /// state arrives.
+  Stream<bool> isSessionAwaitingInteraction(int sessionId) {
+    return _sessionRepository.isAwaitingInteraction(sessionId);
+  }
+
   Stream<SessionState> getSessionStateByOpenID4VCIState(String sessionState) {
     return _sessionRepository.getSessionStateByOpenID4VCIState(sessionState);
   }

--- a/yivi_core/lib/src/data/session_repository.dart
+++ b/yivi_core/lib/src/data/session_repository.dart
@@ -4,6 +4,7 @@ import "package:rxdart/rxdart.dart";
 
 import "../models/event.dart";
 import "../models/schemaless/session_state.dart";
+import "../models/schemaless/session_user_interaction.dart";
 import "irma_repository.dart";
 
 /// SessionRepository manages session states.
@@ -23,6 +24,10 @@ class SessionRepository {
   /// Emits session IDs the first time a [SessionStateEvent] is received for them.
   final _newSessionIdsSubject = PublishSubject<int>();
 
+  /// Session IDs whose last user interaction has been dispatched to Go but
+  /// for which no follow-up [SessionStateEvent] has yet arrived.
+  final _awaitingInteraction = BehaviorSubject<Set<int>>.seeded({});
+
   SessionRepository({required this.repo, required Stream<Event> eventStream}) {
     eventStream.listen(_handleEvent);
   }
@@ -30,6 +35,9 @@ class SessionRepository {
   void _handleEvent(Event event) {
     if (event is SessionStateEvent) {
       _handleSessionStateEvent(event);
+    } else if (event is SessionUserInteractionEvent &&
+        event.type != UserInteractionType.dismiss) {
+      _markAwaitingInteraction(event.sessionId);
     }
   }
 
@@ -45,7 +53,25 @@ class SessionRepository {
     if (isNew) {
       _newSessionIdsSubject.add(state.id);
     }
+
+    // Any new state for this session resolves a pending interaction.
+    if (_awaitingInteraction.value.contains(state.id)) {
+      final next = Set<int>.from(_awaitingInteraction.value)..remove(state.id);
+      _awaitingInteraction.add(next);
+    }
   }
+
+  void _markAwaitingInteraction(int sessionId) {
+    if (_awaitingInteraction.value.contains(sessionId)) return;
+    final next = Set<int>.from(_awaitingInteraction.value)..add(sessionId);
+    _awaitingInteraction.add(next);
+  }
+
+  /// Stream of whether [sessionId] is currently waiting for the next state.
+  Stream<bool> isAwaitingInteraction(int sessionId) => _awaitingInteraction
+      .stream
+      .map((set) => set.contains(sessionId))
+      .distinct();
 
   /// Stream that emits session IDs when a new session is first seen.
   Stream<int> get newSessionIds => _newSessionIdsSubject.stream;
@@ -94,6 +120,10 @@ class SessionRepository {
   }
 
   Future<void> close() async {
-    await Future.wait([_states.close(), _newSessionIdsSubject.close()]);
+    await Future.wait([
+      _states.close(),
+      _newSessionIdsSubject.close(),
+      _awaitingInteraction.close(),
+    ]);
   }
 }

--- a/yivi_core/lib/src/data/session_repository.dart
+++ b/yivi_core/lib/src/data/session_repository.dart
@@ -69,8 +69,7 @@ class SessionRepository {
     // terminal emission. Prevents `_states` from growing unboundedly across
     // the app lifetime.
     if (_isTerminalStatus(state.status)) {
-      final cleaned = Map<int, SessionState>.from(nextStates)
-        ..remove(state.id);
+      final cleaned = Map<int, SessionState>.from(nextStates)..remove(state.id);
       _states.add(UnmodifiableMapView(cleaned));
     }
   }

--- a/yivi_core/lib/src/data/session_repository.dart
+++ b/yivi_core/lib/src/data/session_repository.dart
@@ -61,7 +61,24 @@ class SessionRepository {
       final next = Set<int>.from(_awaitingInteraction.value)..remove(state.id);
       _awaitingInteraction.add(next);
     }
+
+    // Mirror Go's session eviction on terminal status: emit the terminal state
+    // first so consumers (SessionScreen, integration tests) observe it, then
+    // drop the entry from the map. The second emit is filtered out by
+    // [getSessionState]'s `containsKey` guard, so subscribers see exactly one
+    // terminal emission. Prevents `_states` from growing unboundedly across
+    // the app lifetime.
+    if (_isTerminalStatus(state.status)) {
+      final cleaned = Map<int, SessionState>.from(nextStates)
+        ..remove(state.id);
+      _states.add(UnmodifiableMapView(cleaned));
+    }
   }
+
+  static bool _isTerminalStatus(SessionStatus status) =>
+      status == SessionStatus.success ||
+      status == SessionStatus.error ||
+      status == SessionStatus.dismissed;
 
   void _markAwaitingInteraction(int sessionId) {
     if (_awaitingInteraction.value.contains(sessionId)) return;

--- a/yivi_core/lib/src/data/session_repository.dart
+++ b/yivi_core/lib/src/data/session_repository.dart
@@ -75,6 +75,12 @@ class SessionRepository {
       .map((set) => set.contains(sessionId))
       .distinct();
 
+  /// Synchronous read of the current awaiting-interaction state. Used as a
+  /// fallback for the first build after a SessionScreen remounts, before the
+  /// stream subscription has delivered its seed value.
+  bool isAwaitingInteractionNow(int sessionId) =>
+      _awaitingInteraction.value.contains(sessionId);
+
   /// Stream that emits session IDs when a new session is first seen.
   Stream<int> get newSessionIds => _newSessionIdsSubject.stream;
 
@@ -105,7 +111,7 @@ class SessionRepository {
   }
 
   /// Returns the IDs of all sessions currently in the requestPermission state.
-  Future<List<int>> getActiveSessionIds() async {
+  List<int> getActiveSessionIds() {
     return _states.value.entries
         .where((e) => e.value.status == .requestPermission)
         .map((e) => e.key)

--- a/yivi_core/lib/src/data/session_repository.dart
+++ b/yivi_core/lib/src/data/session_repository.dart
@@ -54,7 +54,9 @@ class SessionRepository {
       _newSessionIdsSubject.add(state.id);
     }
 
-    // Any new state for this session resolves a pending interaction.
+    // Any new state for this session resolves a pending interaction. Terminal
+    // statuses (success/error/dismissed) are also state events, so the entry
+    // is cleared on normal session completion as well.
     if (_awaitingInteraction.value.contains(state.id)) {
       final next = Set<int>.from(_awaitingInteraction.value)..remove(state.id);
       _awaitingInteraction.add(next);
@@ -112,7 +114,7 @@ class SessionRepository {
 
   /// Returns whether any session is currently in the requestPermission state.
   /// Optionally excludes a specific session ID from the check.
-  Future<bool> hasActiveSessions({int? excludeSessionId}) async {
+  bool hasActiveSessions({int? excludeSessionId}) {
     final states = _states.value;
     return states.entries.any(
       (e) => e.key != excludeSessionId && e.value.status == .requestPermission,

--- a/yivi_core/lib/src/models/session_events.dart
+++ b/yivi_core/lib/src/models/session_events.dart
@@ -12,7 +12,12 @@ abstract class SessionEvent extends Event {
 
 @JsonSerializable(createFactory: false, fieldRename: .snake)
 class NewSessionEvent extends SessionEvent {
-  NewSessionEvent({required this.request});
+  NewSessionEvent({required this.sessionId, required this.request});
+
+  /// Caller-supplied id (allocated by [IrmaRepository.allocateSessionId]).
+  /// The Go side uses this as the session's identifier so the mobile UI can
+  /// mount [SessionScreen] synchronously without waiting for the first state.
+  final int sessionId;
 
   final SessionPointer request;
 

--- a/yivi_core/lib/src/models/session_events.g.dart
+++ b/yivi_core/lib/src/models/session_events.g.dart
@@ -7,7 +7,10 @@ part of 'session_events.dart';
 // **************************************************************************
 
 Map<String, dynamic> _$NewSessionEventToJson(NewSessionEvent instance) =>
-    <String, dynamic>{'request': instance.request};
+    <String, dynamic>{
+      'session_id': instance.sessionId,
+      'request': instance.request,
+    };
 
 RespondPreAuthorizedCodeFlowPermissionEvent
 _$RespondPreAuthorizedCodeFlowPermissionEventFromJson(

--- a/yivi_core/lib/src/providers/session_state_provider.dart
+++ b/yivi_core/lib/src/providers/session_state_provider.dart
@@ -10,3 +10,15 @@ final sessionStateProvider = StreamProvider.family<SessionState, int>((
   final repo = ref.watch(irmaRepositoryProvider);
   return repo.getSessionState(sessionId);
 });
+
+/// Whether [sessionId] has dispatched a user interaction that's still waiting
+/// for the next [SessionState] from Go. Drives the spinner during Gap B and
+/// also covers paths where the interaction is dispatched outside SessionScreen
+/// (e.g. the OID4VCI auth-code callback).
+final sessionAwaitingInteractionProvider = StreamProvider.family<bool, int>((
+  ref,
+  sessionId,
+) {
+  final repo = ref.watch(irmaRepositoryProvider);
+  return repo.isSessionAwaitingInteraction(sessionId);
+});

--- a/yivi_core/lib/src/providers/session_state_provider.dart
+++ b/yivi_core/lib/src/providers/session_state_provider.dart
@@ -15,10 +15,30 @@ final sessionStateProvider = StreamProvider.family<SessionState, int>((
 /// for the next [SessionState] from Go. Drives the spinner during Gap B and
 /// also covers paths where the interaction is dispatched outside SessionScreen
 /// (e.g. the OID4VCI auth-code callback).
-final sessionAwaitingInteractionProvider = StreamProvider.family<bool, int>((
-  ref,
-  sessionId,
-) {
-  final repo = ref.watch(irmaRepositoryProvider);
-  return repo.isSessionAwaitingInteraction(sessionId);
-});
+///
+/// Backed by a [Notifier] rather than a [StreamProvider] so the value is
+/// available synchronously on the first build of a remount — the underlying
+/// [BehaviorSubject] already knows the answer, but a [StreamProvider] would
+/// report `AsyncValue.loading()` for one frame and cause a spinner flicker.
+class SessionAwaitingInteractionNotifier extends Notifier<bool> {
+  final int sessionId;
+
+  SessionAwaitingInteractionNotifier(this.sessionId);
+
+  @override
+  bool build() {
+    final repo = ref.watch(irmaRepositoryProvider);
+    final sub = repo.isSessionAwaitingInteraction(sessionId).listen((v) {
+      state = v;
+    });
+    ref.onDispose(sub.cancel);
+    return repo.isSessionAwaitingInteractionNow(sessionId);
+  }
+}
+
+final sessionAwaitingInteractionProvider =
+    NotifierProvider.family<
+      SessionAwaitingInteractionNotifier,
+      bool,
+      int
+    >((sessionId) => SessionAwaitingInteractionNotifier(sessionId));

--- a/yivi_core/lib/src/providers/session_state_provider.dart
+++ b/yivi_core/lib/src/providers/session_state_provider.dart
@@ -37,8 +37,6 @@ class SessionAwaitingInteractionNotifier extends Notifier<bool> {
 }
 
 final sessionAwaitingInteractionProvider =
-    NotifierProvider.family<
-      SessionAwaitingInteractionNotifier,
-      bool,
-      int
-    >((sessionId) => SessionAwaitingInteractionNotifier(sessionId));
+    NotifierProvider.family<SessionAwaitingInteractionNotifier, bool, int>(
+      (sessionId) => SessionAwaitingInteractionNotifier(sessionId),
+    );

--- a/yivi_core/lib/src/screens/issue_wizard/issue_wizard.dart
+++ b/yivi_core/lib/src/screens/issue_wizard/issue_wizard.dart
@@ -93,10 +93,7 @@ class _IssueWizardScreenState extends ConsumerState<IssueWizardScreen>
   }
 
   Future<void> _finish(IssueWizardEvent wizard) async {
-    final activeSessions = await _repo.hasActiveSessions();
-    if (!mounted) {
-      return; // can't do anything if our context vanished while awaiting
-    }
+    final activeSessions = _repo.hasActiveSessions();
 
     final navigator = Navigator.of(context);
     if (activeSessions) {

--- a/yivi_core/lib/src/screens/session/session_screen.dart
+++ b/yivi_core/lib/src/screens/session/session_screen.dart
@@ -65,9 +65,6 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
   /// the issuance confirmation screen.
   List<DisclosureDisconSelection>? _pendingDisclosureChoices;
 
-  /// True after dispatching a user interaction (PIN, permission grant, etc.)
-  /// until the next [SessionState] arrives from the backend.
-  bool _awaitingStateUpdate = false;
   bool _hasLongPin = false;
 
   /// Whether the disclosure introduction screen should be shown.
@@ -132,14 +129,10 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
   @override
   Widget build(BuildContext context) {
     final asyncSession = ref.watch(sessionStateProvider(widget.sessionId));
+    final isAwaiting =
+        ref.watch(sessionAwaitingInteractionProvider(widget.sessionId)).value ??
+        false;
     _lastSession = asyncSession;
-
-    // Reset the awaiting flag when a new session state arrives.
-    ref.listen(sessionStateProvider(widget.sessionId), (prev, next) {
-      if (_awaitingStateUpdate && next.hasValue) {
-        setState(() => _awaitingStateUpdate = false);
-      }
-    });
 
     // Track the latest non-null remainingTxCodeAttempts so that, if the
     // session subsequently errors out, we can detect the tx_code-lockout
@@ -171,7 +164,7 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
     // Show loading while waiting for a state update after user interaction,
     // except when on the PIN screen — it handles its own loading overlay
     // and must stay mounted so didUpdateWidget can detect wrong PIN attempts.
-    if (_awaitingStateUpdate && asyncSession.value?.status != .requestPin) {
+    if (isAwaiting && asyncSession.value?.status != .requestPin) {
       return _buildLoadingScreen(asyncSession.value);
     }
 
@@ -211,7 +204,7 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
             title: _getAppBarTitle(session),
             remainingAttempts: session.remainingPinAttempts,
             blockedTimeSeconds: session.pinBlockedTimeSeconds,
-            submitting: _awaitingStateUpdate,
+            submitting: isAwaiting,
             maxPinSize: _hasLongPin ? 16 : 5,
             onPinEntered: (pin) => _submitPin(pin),
             onCancel: _dismissSession,
@@ -336,7 +329,6 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
   }
 
   void _submitPin(String pin) {
-    setState(() => _awaitingStateUpdate = true);
     _repo.bridgedDispatch(
       SessionUserInteractionEvent.pin(
         sessionId: widget.sessionId,
@@ -398,7 +390,6 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
   }
 
   void _grantPermission(List<DisclosureDisconSelection> disclosureChoices) {
-    setState(() => _awaitingStateUpdate = true);
     final repo = ref.read(irmaRepositoryProvider);
     repo.bridgedDispatch(
       SessionUserInteractionEvent.permission(
@@ -569,7 +560,6 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
     SessionState session, {
     required String? transactionCode,
   }) {
-    setState(() => _awaitingStateUpdate = true);
     _repo.bridgedDispatch(
       SessionUserInteractionEvent.preAuthorizedCodePermission(
         sessionId: session.id,

--- a/yivi_core/lib/src/screens/session/session_screen.dart
+++ b/yivi_core/lib/src/screens/session/session_screen.dart
@@ -134,9 +134,9 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
   @override
   Widget build(BuildContext context) {
     final asyncSession = ref.watch(sessionStateProvider(widget.sessionId));
-    final isAwaiting =
-        ref.watch(sessionAwaitingInteractionProvider(widget.sessionId)).value ??
-        false;
+    final isAwaiting = ref.watch(
+      sessionAwaitingInteractionProvider(widget.sessionId),
+    );
     _lastSession = asyncSession;
 
     // Track the latest non-null remainingTxCodeAttempts so that, if the

--- a/yivi_core/lib/src/screens/session/session_screen.dart
+++ b/yivi_core/lib/src/screens/session/session_screen.dart
@@ -112,13 +112,18 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
 
   @override
   void dispose() {
-    // If the screen is being disposed while the session is still active, dismiss it.
+    // Dismiss unless we've already observed a terminal state. A null
+    // `_lastSession?.value` means Go hasn't emitted any state yet — that
+    // window exists because SessionScreen is now pushed before the first
+    // SessionStateEvent — and backing out during it must still dismiss the
+    // Go-side session.
     // We use cached values because ref is unsafe to use during dispose.
-    final session = _lastSession?.value;
-    if (session != null &&
-        session.status != SessionStatus.success &&
-        session.status != SessionStatus.error &&
-        session.status != SessionStatus.dismissed) {
+    final status = _lastSession?.value?.status;
+    final isTerminal =
+        status == SessionStatus.success ||
+        status == SessionStatus.error ||
+        status == SessionStatus.dismissed;
+    if (!isTerminal) {
       _repo.bridgedDispatch(
         SessionUserInteractionEvent.dismiss(sessionId: widget.sessionId),
       );

--- a/yivi_core/lib/src/screens/session/session_screen.dart
+++ b/yivi_core/lib/src/screens/session/session_screen.dart
@@ -36,10 +36,12 @@ import "widgets/session_scaffold.dart";
 
 /// Displays the current [SessionState] for a given session ID.
 ///
-/// This widget is purely presentational — it does not modify the session state.
-/// Navigation is driven externally: the [SchemalessSessionListener] pushes this
-/// screen when a new session appears, and this screen pops itself when the
-/// session status becomes [SessionStatus.dismissed].
+/// Pushed by [handlePointer] immediately after dispatching `NewSessionEvent`,
+/// with a Dart-allocated session id. While Go has not yet emitted the first
+/// state, the existing `asyncSession.isLoading` branch renders the loading
+/// screen — this is the spinner during the QR-scan → first-state window.
+/// The screen pops itself when the session status becomes
+/// [SessionStatus.dismissed].
 class SessionScreen extends ConsumerStatefulWidget {
   final int sessionId;
   final bool hasUnderlyingSession;

--- a/yivi_core/lib/src/util/handle_pointer.dart
+++ b/yivi_core/lib/src/util/handle_pointer.dart
@@ -42,14 +42,13 @@ void _startSession(
   BuildContext context,
   SessionPointer sessionPointer, {
   bool pushReplacement = false,
-}) async {
+}) {
   final repo = IrmaRepositoryProvider.of(context);
 
   final sessionId = repo.allocateSessionId();
   // Any session active at this moment is "underlying" — ours does not exist on
   // the Go side yet, so we don't need to exclude it.
-  final hasUnderlying = await repo.hasActiveSessions();
-  if (!context.mounted) return;
+  final hasUnderlying = repo.hasActiveSessions();
 
   repo.bridgedDispatch(
     NewSessionEvent(sessionId: sessionId, request: sessionPointer),

--- a/yivi_core/lib/src/util/handle_pointer.dart
+++ b/yivi_core/lib/src/util/handle_pointer.dart
@@ -34,31 +34,34 @@ Future<void> handlePointer(
   }
 }
 
-/// Dispatches a NewSessionEvent to Go and pushes the session screen
-/// when Go responds with a [SessionStateEvent] containing the session ID.
+/// Dispatches a NewSessionEvent to Go and pushes [SessionScreen] synchronously.
+/// The session id is allocated Dart-side so the screen can mount immediately
+/// and render its existing "no state yet" loading branch while Go contacts
+/// the relying party.
 void _startSession(
   BuildContext context,
   SessionPointer sessionPointer, {
   bool pushReplacement = false,
-}) {
+}) async {
   final repo = IrmaRepositoryProvider.of(context);
-  repo.bridgedDispatch(NewSessionEvent(request: sessionPointer));
 
-  // Listen for the next new session ID and push the session screen.
-  repo.getNewSessionIds().first.then((sessionId) async {
-    if (!context.mounted) return;
-    final hasUnderlying = await repo.hasActiveSessions(
-      excludeSessionId: sessionId,
-    );
-    if (!context.mounted) return;
-    final params = SessionRouteParams(
-      sessionId: sessionId,
-      hasUnderlyingSession: hasUnderlying,
-    );
-    if (pushReplacement) {
-      context.pushReplacementSessionScreen(params);
-    } else {
-      context.pushSessionScreen(params);
-    }
-  });
+  final sessionId = repo.allocateSessionId();
+  // Any session active at this moment is "underlying" — ours does not exist on
+  // the Go side yet, so we don't need to exclude it.
+  final hasUnderlying = await repo.hasActiveSessions();
+  if (!context.mounted) return;
+
+  repo.bridgedDispatch(
+    NewSessionEvent(sessionId: sessionId, request: sessionPointer),
+  );
+
+  final params = SessionRouteParams(
+    sessionId: sessionId,
+    hasUnderlyingSession: hasUnderlying,
+  );
+  if (pushReplacement) {
+    context.pushReplacementSessionScreen(params);
+  } else {
+    context.pushSessionScreen(params);
+  }
 }


### PR DESCRIPTION
Add spinner progress indicator after each session user interaction and before the session has loaded.
This fixes #543.

Also added widget previews for all sorts of scenarios for the YiviCredentialCard widget to have an overview of how it behaves.
