### PR TITLE
Add requestor header to issuance screens

### DIFF
--- a/yivi_app/integration_test/helpers/helpers.dart
+++ b/yivi_app/integration_test/helpers/helpers.dart
@@ -26,6 +26,7 @@ import "package:yivi_core/src/widgets/credential_card/yivi_credential_card_heade
 import "package:yivi_core/src/widgets/irma_app_bar.dart";
 import "package:yivi_core/src/widgets/irma_avatar.dart";
 import "package:yivi_core/src/widgets/irma_card.dart";
+import "package:yivi_core/src/widgets/irma_icon_indicator.dart";
 import "package:yivi_core/src/widgets/radio_indicator.dart";
 import "package:yivi_core/src/widgets/requestor_header.dart";
 import "package:yivi_core/src/widgets/yivi_themed_button.dart";
@@ -241,6 +242,10 @@ Future<void> issueCredentials(
   var issuancePageFinder = find.byType(IssuancePermission);
   await tester.waitFor(issuancePageFinder);
 
+  // IRMA-scheme requestors land at verified=true via
+  // requestorInfoToTrustedParty in irmago client/session_handler.go.
+  expectRequestorHeader(tester, verified: true, locale: locale);
+
   // Check whether all credentials are displayed.
   expect(
     find.byType(YiviCredentialCard),
@@ -362,6 +367,75 @@ Future<void> evaluateRequestor(
     matching: find.text(expectedName),
   );
   expect(nameFinder, findsOneWidget);
+}
+
+/// Asserts that a RequestorHeader is on screen on an issuance flow and
+/// reports the expected verification state via its IrmaStatusIndicator.
+/// When [issuerName] is supplied, asserts the exact concatenated text
+/// `[issuerName] [suffix]` inside the header's RichText. When omitted,
+/// only asserts the suffix substring (useful from shared helpers where the
+/// requestor's display name depends on backend setup). The suffix strings
+/// mirror `issuance.requestor_verification.{verified,unverified}_suffix` —
+/// bump them here if the i18n is reworded. Pass [locale] when asserting on
+/// non-English flows so the right translation is checked.
+void expectRequestorHeader(
+  WidgetTester tester, {
+  required bool verified,
+  String? issuerName,
+  Locale locale = const Locale("en", "EN"),
+}) {
+  expect(find.byType(RequestorHeader), findsOneWidget);
+  final indicator = tester.widget<IrmaStatusIndicator>(
+    find.byType(IrmaStatusIndicator),
+  );
+  expect(indicator.success, verified);
+
+  const suffixesByLanguage = {
+    "en": (
+      verified:
+          "wants to add data to your wallet. "
+          "This is a known party that has registered itself with Yivi.",
+      unverified:
+          "wants to add data to your wallet. "
+          "Warning: this party is not known by Yivi.",
+    ),
+    "nl": (
+      verified:
+          "wil gegevens aan je wallet toevoegen. "
+          "Dit is een bekende partij die zich bij Yivi heeft geregistreerd.",
+      unverified:
+          "wil gegevens aan je wallet toevoegen. "
+          "Waarschuwing: deze partij is niet bekend bij Yivi.",
+    ),
+    "de": (
+      verified:
+          "möchte Daten zu Ihrer Brieftasche hinzufügen. "
+          "Dies ist eine bekannte Partei, die sich bei Yivi registriert hat.",
+      unverified:
+          "möchte Daten zu Ihrer Brieftasche hinzufügen. "
+          "Warnung: Diese Partei ist Yivi nicht bekannt.",
+    ),
+  };
+  final pair = suffixesByLanguage[locale.languageCode];
+  if (pair == null) {
+    fail(
+      "expectRequestorHeader has no suffix strings for locale "
+      "'${locale.languageCode}'. Add them to suffixesByLanguage.",
+    );
+  }
+  final suffix = verified ? pair.verified : pair.unverified;
+
+  if (issuerName != null) {
+    expect(
+      find.text("$issuerName $suffix", findRichText: true),
+      findsOneWidget,
+    );
+  } else {
+    expect(
+      find.textContaining(suffix, findRichText: true),
+      findsAtLeast(1),
+    );
+  }
 }
 
 /// One label-value entry in an [attributes] list. The value is one of:

--- a/yivi_app/integration_test/issue_sdjwt_over_irma_test.dart
+++ b/yivi_app/integration_test/issue_sdjwt_over_irma_test.dart
@@ -68,6 +68,14 @@ Future<void> testIssuanceLowInstanceCountNoReobtainButtonDuringIssuance(
   var issuancePageFinder = find.byType(IssuancePermission);
   await tester.waitFor(issuancePageFinder);
 
+  // IRMA-scheme requestors land at verified=true via
+  // requestorInfoToTrustedParty in irmago client/session_handler.go.
+  expectRequestorHeader(
+    tester,
+    verified: true,
+    issuerName: "Demo Privacy by Design Foundation via SIDN",
+  );
+
   // Make sure it's not shown as nearly expired even though the instance count is low.
   // We don't want to show a re-obtain button during issuance...
   await evaluateCredentialCard(

--- a/yivi_app/integration_test/openid4vci_authcode_issuance_test.dart
+++ b/yivi_app/integration_test/openid4vci_authcode_issuance_test.dart
@@ -22,6 +22,7 @@ import "package:yivi_core/src/screens/session/widgets/issuance_permission.dart";
 import "package:yivi_core/src/screens/session/widgets/issuance_success_screen.dart";
 import "package:yivi_core/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart";
 import "package:yivi_core/src/widgets/credential_card/yivi_credential_card.dart";
+import "package:yivi_core/src/widgets/requestor_header.dart";
 
 import "helpers/helpers.dart";
 import "irma_binding.dart";
@@ -140,6 +141,18 @@ Future<void> testIssueEmailOpenID4VCIAuthCode(
     issuerState: offer.issuerState,
     walletState: walletState,
   );
+
+  // Pending confirmation screen: the user must tap "Open browser" before the
+  // browser is launched. Verify the RequestorHeader is on screen and that the
+  // credential name + issuer name appear so the user knows what they're about
+  // to consent to. The issuer name renders in both the header and the card,
+  // hence findsAtLeast(1).
+  await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
+  expect(find.byType(RequestorHeader), findsOneWidget);
+  expect(find.text("Email Credential (SD-JWT)"), findsOneWidget);
+  expect(find.text("AuthCode Issuer"), findsAtLeast(1));
+  await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
+
   dispatchAuthCallback(
     irmaBinding.repository,
     walletState: walletState,
@@ -229,7 +242,10 @@ Future<void> testIssueOrganizationOpenID4VCIAuthCode(
     walletState: walletState,
   );
 
-  // Wallet auto-launched the browser; dispatch the synthetic redirect.
+  // Confirm and launch via the pending screen, then dispatch the synthetic
+  // redirect to mimic the browser callback.
+  await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
+  await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
   dispatchAuthCallback(
     irmaBinding.repository,
     walletState: walletState,
@@ -295,8 +311,9 @@ Future<void> testDismissOnPendingScreen(
   );
   irmaBinding.repository.startTestSessionFromUrl(offer.uri);
 
-  // The wallet auto-launches the browser. Without a synthetic redirect, the
-  // session stays in requestAuthorizationCode and the pending screen renders.
+  // When the session enters requestAuthorizationCode, the pending screen is
+  // rendered awaiting the user to tap "Open browser". Without that tap, no
+  // browser launch happens and the session stays put.
   await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
 
   // Tap "Cancel" to dismiss the session directly.
@@ -339,7 +356,10 @@ Future<void> testDismissOnIssuancePermissionScreen(
     walletState: walletState,
   );
 
-  // Browser auto-launched; dispatch the synthetic redirect to advance state.
+  // Confirm and launch via the pending screen, then dispatch the synthetic
+  // redirect to advance state.
+  await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
+  await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
   dispatchAuthCallback(
     irmaBinding.repository,
     walletState: walletState,

--- a/yivi_app/integration_test/openid4vci_authcode_issuance_test.dart
+++ b/yivi_app/integration_test/openid4vci_authcode_issuance_test.dart
@@ -22,7 +22,6 @@ import "package:yivi_core/src/screens/session/widgets/issuance_permission.dart";
 import "package:yivi_core/src/screens/session/widgets/issuance_success_screen.dart";
 import "package:yivi_core/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart";
 import "package:yivi_core/src/widgets/credential_card/yivi_credential_card.dart";
-import "package:yivi_core/src/widgets/requestor_header.dart";
 
 import "helpers/helpers.dart";
 import "irma_binding.dart";
@@ -143,14 +142,12 @@ Future<void> testIssueEmailOpenID4VCIAuthCode(
   );
 
   // Pending confirmation screen: the user must tap "Open browser" before the
-  // browser is launched. Verify the RequestorHeader is on screen and that the
-  // credential name + issuer name appear so the user knows what they're about
-  // to consent to. The issuer name renders in both the header and the card,
-  // hence findsAtLeast(1).
+  // browser is launched. Verify the RequestorHeader is on screen, reports
+  // unverified (VCI issuers are always unverified), and that the credential
+  // name appears so the user knows what they're about to consent to.
   await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
-  expect(find.byType(RequestorHeader), findsOneWidget);
+  expectRequestorHeader(tester, verified: false, issuerName: "AuthCode Issuer");
   expect(find.text("Email Credential (SD-JWT)"), findsOneWidget);
-  expect(find.text("AuthCode Issuer"), findsAtLeast(1));
   await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
 
   dispatchAuthCallback(
@@ -159,8 +156,10 @@ Future<void> testIssueEmailOpenID4VCIAuthCode(
     code: code,
   );
 
-  // Permission screen: IssuancePermission with filled values
+  // Permission screen: IssuancePermission with filled values. The
+  // RequestorHeader continues to report unverified for the VCI issuer.
   await tester.waitFor(find.byType(IssuancePermission));
+  expectRequestorHeader(tester, verified: false, issuerName: "AuthCode Issuer");
   await evaluateCredentialCard(
     tester,
     find.byType(YiviCredentialCard).first,

--- a/yivi_app/integration_test/openid4vci_issuance_test.dart
+++ b/yivi_app/integration_test/openid4vci_issuance_test.dart
@@ -165,8 +165,10 @@ Future<void> testIssueEmailOpenID4VCI(
   irmaBinding.repository.startTestSessionFromUrl(offer.uri);
 
   // No tx code: the wallet auto-grants and lands directly on IssuancePermission
-  // with filled values.
+  // with filled values. The header reports unverified because VCI issuers are
+  // always unverified by irmago (see eudi/openid4vci/client.go convertToTrustedParty).
   await tester.waitFor(find.byType(IssuancePermission));
+  expectRequestorHeader(tester, verified: false, issuerName: "Test Issuer");
   await evaluateCredentialCard(
     tester,
     find.byType(YiviCredentialCard).first,

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -451,7 +451,11 @@
     },
     "requestor_verification": {
       "verified_suffix": "möchte Daten zu Ihrer Brieftasche hinzufügen. Dies ist eine bekannte Partei, die sich bei Yivi registriert hat.",
-      "unverified_suffix": "möchte Daten zu Ihrer Brieftasche hinzufügen. Warnung: Diese Partei ist Yivi nicht bekannt."
+      "unverified_suffix": "möchte Daten zu Ihrer Brieftasche hinzufügen. Warnung: Diese Partei ist Yivi nicht bekannt.",
+      "multi_issuer_verified_bold": "Mehrere Parteien",
+      "multi_issuer_verified_suffix": " möchten Daten zu Ihrer Brieftasche hinzufügen. Alle sind Yivi bekannt.",
+      "multi_issuer_unverified_bold": "Mehrere Parteien",
+      "multi_issuer_unverified_suffix": " möchten Daten zu Ihrer Brieftasche hinzufügen. Warnung: Nicht alle sind Yivi bekannt."
     }
   },
   "email_issuance": {

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -444,10 +444,14 @@
       "pending": {
         "title": "Daten hinzufügen",
         "header": "Im Browser fortfahren",
-        "body": "Wir haben den Browser geöffnet, damit Sie die Schritte bei {issuer} abschließen können. Wenn Sie fertig sind, kehren Sie automatisch hierher zurück.",
-        "open_browser": "Browser erneut öffnen",
+        "body": "Um die folgenden Daten zu Ihrer Brieftasche hinzuzufügen, fahren Sie im Browser fort. Wenn Sie fertig sind, kehren Sie automatisch hierher zurück.",
+        "open_browser": "Browser öffnen",
         "cancel": "Abbrechen"
       }
+    },
+    "requestor_verification": {
+      "verified_suffix": "möchte Daten zu Ihrer Brieftasche hinzufügen. Dies ist eine bekannte Partei, die sich bei Yivi registriert hat.",
+      "unverified_suffix": "möchte Daten zu Ihrer Brieftasche hinzufügen. Warnung: Diese Partei ist Yivi nicht bekannt."
     }
   },
   "email_issuance": {

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -444,10 +444,14 @@
       "pending": {
         "title": "Add data",
         "header": "Continue in your browser",
-        "body": "We've opened the browser so you can complete the steps at {issuer}. When you're done, you'll return here automatically.",
-        "open_browser": "Open browser again",
+        "body": "To add the following data to your wallet, continue in the browser. You'll return here automatically when you're done.",
+        "open_browser": "Open browser",
         "cancel": "Cancel"
       }
+    },
+    "requestor_verification": {
+      "verified_suffix": "wants to add data to your wallet. This is a known party that has registered itself with Yivi.",
+      "unverified_suffix": "wants to add data to your wallet. Warning: this party is not known by Yivi."
     }
   },
   "email_issuance": {

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -451,7 +451,11 @@
     },
     "requestor_verification": {
       "verified_suffix": "wants to add data to your wallet. This is a known party that has registered itself with Yivi.",
-      "unverified_suffix": "wants to add data to your wallet. Warning: this party is not known by Yivi."
+      "unverified_suffix": "wants to add data to your wallet. Warning: this party is not known by Yivi.",
+      "multi_issuer_verified_bold": "Multiple parties",
+      "multi_issuer_verified_suffix": " want to add data to your wallet. All of them are known by Yivi.",
+      "multi_issuer_unverified_bold": "Multiple parties",
+      "multi_issuer_unverified_suffix": " want to add data to your wallet. Warning: not all of them are known by Yivi."
     }
   },
   "email_issuance": {

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -451,7 +451,11 @@
     },
     "requestor_verification": {
       "verified_suffix": "wil gegevens aan je wallet toevoegen. Dit is een bekende partij die zich bij Yivi heeft geregistreerd.",
-      "unverified_suffix": "wil gegevens aan je wallet toevoegen. Waarschuwing: deze partij is niet bekend bij Yivi."
+      "unverified_suffix": "wil gegevens aan je wallet toevoegen. Waarschuwing: deze partij is niet bekend bij Yivi.",
+      "multi_issuer_verified_bold": "Meerdere partijen",
+      "multi_issuer_verified_suffix": " willen gegevens aan je wallet toevoegen. Allemaal zijn ze bekend bij Yivi.",
+      "multi_issuer_unverified_bold": "Meerdere partijen",
+      "multi_issuer_unverified_suffix": " willen gegevens aan je wallet toevoegen. Waarschuwing: niet allemaal zijn ze bekend bij Yivi."
     }
   },
   "email_issuance": {

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -444,10 +444,14 @@
       "pending": {
         "title": "Gegevens toevoegen",
         "header": "Ga verder in je browser",
-        "body": "We hebben de browser geopend zodat je de stappen bij {issuer} kunt voltooien. Als je klaar bent kom je automatisch terug.",
-        "open_browser": "Browser opnieuw openen",
+        "body": "Om de volgende gegevens toe te voegen aan je wallet, ga je verder in de browser. Als je klaar bent kom je automatisch terug.",
+        "open_browser": "Browser openen",
         "cancel": "Annuleren"
       }
+    },
+    "requestor_verification": {
+      "verified_suffix": "wil gegevens aan je wallet toevoegen. Dit is een bekende partij die zich bij Yivi heeft geregistreerd.",
+      "unverified_suffix": "wil gegevens aan je wallet toevoegen. Waarschuwing: deze partij is niet bekend bij Yivi."
     }
   },
   "email_issuance": {

--- a/yivi_core/lib/src/screens/activity/widgets/activity_detail_disclosure.dart
+++ b/yivi_core/lib/src/screens/activity/widgets/activity_detail_disclosure.dart
@@ -60,7 +60,13 @@ class ActivityDetailDisclosure extends StatelessWidget {
           isHeader: true,
         ),
         SizedBox(height: theme.smallSpacing),
-        RequestorHeader(requestor: logEntry.requestor),
+        RequestorHeader(
+          requestor: logEntry.requestor,
+          verifiedSuffixKey:
+              "disclosure_permission.overview.requestor_verification.verified_suffix",
+          unverifiedSuffixKey:
+              "disclosure_permission.overview.requestor_verification.unverified_suffix",
+        ),
       ],
     );
   }

--- a/yivi_core/lib/src/screens/activity/widgets/activity_detail_issuance.dart
+++ b/yivi_core/lib/src/screens/activity/widgets/activity_detail_issuance.dart
@@ -16,7 +16,6 @@ class ActivityDetailIssuance extends StatelessWidget {
     final theme = IrmaTheme.of(context);
 
     final issuanceLog = logEntry.issuanceLog!;
-    final requestor = issuanceLog.issuer;
 
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -45,14 +44,10 @@ class ActivityDetailIssuance extends StatelessWidget {
             isHeader: true,
           ),
           SizedBox(height: theme.smallSpacing),
-          RequestorHeader(
-            requestor: requestor,
-            isVerified: requestor?.verified,
-            verifiedSuffixKey:
-                "issuance.requestor_verification.verified_suffix",
-            unverifiedSuffixKey:
-                "issuance.requestor_verification.unverified_suffix",
-          ),
+          if (issuanceLog.credentials.isNotEmpty)
+            IssuersHeader(
+              issuers: issuanceLog.credentials.map((c) => c.issuer).toList(),
+            ),
           SizedBox(height: theme.defaultSpacing),
         ],
         TranslatedText(

--- a/yivi_core/lib/src/screens/activity/widgets/activity_detail_issuance.dart
+++ b/yivi_core/lib/src/screens/activity/widgets/activity_detail_issuance.dart
@@ -48,6 +48,10 @@ class ActivityDetailIssuance extends StatelessWidget {
           RequestorHeader(
             requestor: requestor,
             isVerified: requestor?.verified,
+            verifiedSuffixKey:
+                "issuance.requestor_verification.verified_suffix",
+            unverifiedSuffixKey:
+                "issuance.requestor_verification.unverified_suffix",
           ),
           SizedBox(height: theme.defaultSpacing),
         ],

--- a/yivi_core/lib/src/screens/session/session_screen.dart
+++ b/yivi_core/lib/src/screens/session/session_screen.dart
@@ -77,9 +77,8 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
   /// Whether the user has acknowledged the issuance-during-disclosure completion.
   bool _issueDuringDisclosureAcknowledged = false;
 
-  /// True after the OID4VCI side effect (auto-grant or browser launch) has
-  /// fired for the current session, so we don't fire it again on rebuilds or
-  /// when the user returns from a cancelled browser flow.
+  /// True after the OID4VCI pre-auth auto-grant has fired for the current
+  /// session, so we don't fire it again on rebuilds.
   bool _autoTriggeredForOpenID4VCI = false;
 
   /// Tracks the most recent non-null `remainingTxCodeAttempts`. When the
@@ -160,9 +159,6 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
           session.transactionCodeParameters == null) {
         _autoTriggeredForOpenID4VCI = true;
         _grantPreAuthorizedCode(session, transactionCode: null);
-      } else if (session.status == SessionStatus.requestAuthorizationCode) {
-        _autoTriggeredForOpenID4VCI = true;
-        _repo.authenticateOpenID4VCI(session.authorizationRequestUrl!);
       }
     });
 
@@ -323,10 +319,12 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
       return _buildLoadingScreen(session);
     }
 
-    // requestAuthorizationCode: browser auto-opened via ref.listen. This
-    // screen is shown when the user returns to the app without completing.
+    // requestAuthorizationCode: the user must tap "Open browser" on this
+    // screen to launch the issuer flow. Shown on first entry and whenever
+    // the user returns to the app without completing the browser flow.
     return OpenID4VCIAuthCodePendingScreen(
-      issuer: session.offeredCredentialTypes!.first.issuer,
+      requestor: session.requestor,
+      offeredCredentialTypes: session.offeredCredentialTypes!,
       onOpenBrowser: () =>
           _repo.authenticateOpenID4VCI(session.authorizationRequestUrl!),
       onDismiss: _dismissSession,

--- a/yivi_core/lib/src/screens/session/session_screen.dart
+++ b/yivi_core/lib/src/screens/session/session_screen.dart
@@ -323,7 +323,6 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
     // screen to launch the issuer flow. Shown on first entry and whenever
     // the user returns to the app without completing the browser flow.
     return OpenID4VCIAuthCodePendingScreen(
-      requestor: session.requestor,
       offeredCredentialTypes: session.offeredCredentialTypes!,
       onOpenBrowser: () =>
           _repo.authenticateOpenID4VCI(session.authorizationRequestUrl!),

--- a/yivi_core/lib/src/screens/session/widgets/disclosure_choices_overview.dart
+++ b/yivi_core/lib/src/screens/session/widgets/disclosure_choices_overview.dart
@@ -252,6 +252,10 @@ class _DisclosureChoicesOverviewState
               RequestorHeader(
                 requestor: session.requestor,
                 isVerified: session.requestor.verified,
+                verifiedSuffixKey:
+                    "disclosure_permission.overview.requestor_verification.verified_suffix",
+                unverifiedSuffixKey:
+                    "disclosure_permission.overview.requestor_verification.unverified_suffix",
               ),
 
               if (widget.hasIssueDuringDisclosure)

--- a/yivi_core/lib/src/screens/session/widgets/issuance_permission.dart
+++ b/yivi_core/lib/src/screens/session/widgets/issuance_permission.dart
@@ -5,7 +5,7 @@ import "../../../models/schemaless/schemaless_events.dart" as schemaless;
 import "../../../theme/theme.dart";
 import "../../../widgets/credential_card/yivi_credential_card.dart";
 import "../../../widgets/irma_bottom_bar.dart";
-import "../../../widgets/irma_quote.dart";
+import "../../../widgets/requestor_header.dart";
 import "session_scaffold.dart";
 
 class IssuancePermission extends StatelessWidget {
@@ -52,14 +52,16 @@ class IssuancePermission extends StatelessWidget {
     final theme = IrmaTheme.of(context);
 
     return ListView(
-      padding: EdgeInsets.symmetric(horizontal: theme.defaultSpacing),
+      padding: EdgeInsets.only(
+        left: theme.defaultSpacing,
+        right: theme.defaultSpacing,
+        top: theme.smallSpacing,
+      ),
       children: [
-        Padding(
-          padding: EdgeInsets.symmetric(vertical: theme.smallSpacing),
-          child: IrmaQuote(
-            quote: FlutterI18n.translate(context, "issuance.description"),
-          ),
+        IssuersHeader(
+          issuers: issuedCredentials.map((c) => c.issuer).toList(),
         ),
+        SizedBox(height: theme.smallSpacing),
         ...issuedCredentials.map(
           (credential) => Padding(
             padding: EdgeInsets.only(bottom: theme.defaultSpacing),

--- a/yivi_core/lib/src/screens/session/widgets/issue_during_disclosure_screen.dart
+++ b/yivi_core/lib/src/screens/session/widgets/issue_during_disclosure_screen.dart
@@ -157,6 +157,10 @@ class _IssueDuringDisclosureScreenState
                       RequestorHeader(
                         requestor: requestor,
                         isVerified: requestor.verified,
+                        verifiedSuffixKey:
+                            "disclosure_permission.overview.requestor_verification.verified_suffix",
+                        unverifiedSuffixKey:
+                            "disclosure_permission.overview.requestor_verification.unverified_suffix",
                       ),
                     SessionProgressIndicator(
                       step: 1,

--- a/yivi_core/lib/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart
+++ b/yivi_core/lib/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart
@@ -2,7 +2,6 @@ import "package:flutter/material.dart";
 import "package:flutter_i18n/flutter_i18n.dart";
 
 import "../../../models/schemaless/credential_store.dart";
-import "../../../models/schemaless/schemaless_events.dart";
 import "../../../theme/theme.dart";
 import "../../../widgets/credential_card/yivi_credential_card.dart";
 import "../../../widgets/irma_bottom_bar.dart";
@@ -11,14 +10,12 @@ import "../../../widgets/requestor_header.dart";
 import "session_scaffold.dart";
 
 class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
-  final TrustedParty requestor;
   final List<CredentialDescriptor> offeredCredentialTypes;
   final VoidCallback onOpenBrowser;
   final VoidCallback onDismiss;
 
   const OpenID4VCIAuthCodePendingScreen({
     super.key,
-    required this.requestor,
     required this.offeredCredentialTypes,
     required this.onOpenBrowser,
     required this.onDismiss,
@@ -50,13 +47,8 @@ class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
           top: theme.smallSpacing,
         ),
         children: [
-          RequestorHeader(
-            requestor: requestor,
-            isVerified: requestor.verified,
-            verifiedSuffixKey:
-                "issuance.requestor_verification.verified_suffix",
-            unverifiedSuffixKey:
-                "issuance.requestor_verification.unverified_suffix",
+          IssuersHeader(
+            issuers: offeredCredentialTypes.map((d) => d.issuer).toList(),
           ),
           Padding(
             padding: EdgeInsets.symmetric(vertical: theme.smallSpacing),

--- a/yivi_core/lib/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart
+++ b/yivi_core/lib/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart
@@ -1,21 +1,25 @@
 import "package:flutter/material.dart";
 import "package:flutter_i18n/flutter_i18n.dart";
 
+import "../../../models/schemaless/credential_store.dart";
 import "../../../models/schemaless/schemaless_events.dart";
 import "../../../theme/theme.dart";
-import "../../../util/language.dart";
+import "../../../widgets/credential_card/yivi_credential_card.dart";
 import "../../../widgets/irma_bottom_bar.dart";
-import "../../../widgets/translated_text.dart";
+import "../../../widgets/irma_quote.dart";
+import "../../../widgets/requestor_header.dart";
 import "session_scaffold.dart";
 
 class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
-  final TrustedParty issuer;
+  final TrustedParty requestor;
+  final List<CredentialDescriptor> offeredCredentialTypes;
   final VoidCallback onOpenBrowser;
   final VoidCallback onDismiss;
 
   const OpenID4VCIAuthCodePendingScreen({
     super.key,
-    required this.issuer,
+    required this.requestor,
+    required this.offeredCredentialTypes,
     required this.onOpenBrowser,
     required this.onDismiss,
   });
@@ -23,7 +27,6 @@ class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = IrmaTheme.of(context);
-    final issuerName = getTranslation(context, issuer.name);
 
     return SessionScaffold(
       appBarTitle: "issuance.authorization_code.pending.title",
@@ -40,28 +43,41 @@ class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
         ),
         onSecondaryPressed: onDismiss,
       ),
-      body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.all(theme.defaultSpacing),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SizedBox(height: theme.defaultSpacing),
-              TranslatedText(
-                "issuance.authorization_code.pending.header",
-                isHeader: true,
-                style: theme.textTheme.bodyLarge!.copyWith(
-                  color: theme.neutralExtraDark,
-                ),
-              ),
-              SizedBox(height: theme.defaultSpacing),
-              TranslatedText(
-                "issuance.authorization_code.pending.body",
-                translationParams: {"issuer": issuerName},
-              ),
-            ],
-          ),
+      body: ListView(
+        padding: EdgeInsets.only(
+          left: theme.defaultSpacing,
+          right: theme.defaultSpacing,
+          top: theme.smallSpacing,
         ),
+        children: [
+          RequestorHeader(
+            requestor: requestor,
+            isVerified: requestor.verified,
+            verifiedSuffixKey:
+                "issuance.requestor_verification.verified_suffix",
+            unverifiedSuffixKey:
+                "issuance.requestor_verification.unverified_suffix",
+          ),
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: theme.smallSpacing),
+            child: IrmaQuote(
+              quote: FlutterI18n.translate(
+                context,
+                "issuance.authorization_code.pending.body",
+              ),
+            ),
+          ),
+          ...offeredCredentialTypes.map(
+            (descriptor) => Padding(
+              padding: EdgeInsets.only(bottom: theme.defaultSpacing),
+              child: YiviCredentialCard.fromDescriptor(
+                descriptor: descriptor,
+                compact: false,
+                hideNotObtainable: true,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/yivi_core/lib/src/widgets/credential_card/yivi_credential_card.dart
+++ b/yivi_core/lib/src/widgets/credential_card/yivi_credential_card.dart
@@ -141,6 +141,7 @@ class YiviCredentialCard extends ConsumerWidget {
     Widget? headerTrailing,
     IrmaCardStyle style = IrmaCardStyle.normal,
     EdgeInsetsGeometry? padding,
+    bool hideNotObtainable = false,
   }) : this(
          key: key,
          credentialName: descriptor.name,
@@ -191,6 +192,7 @@ class YiviCredentialCard extends ConsumerWidget {
          style: style,
          padding: padding,
          hideFooter: true,
+         hideNotObtainable: hideNotObtainable,
        );
 
   YiviCredentialCard.fromDescriptorWithEmptyAttributeValues({

--- a/yivi_core/lib/src/widgets/requestor_header.dart
+++ b/yivi_core/lib/src/widgets/requestor_header.dart
@@ -28,8 +28,15 @@ _buildRequestorAvatar({
 class RequestorHeader extends StatelessWidget {
   final TrustedParty? requestor;
   final bool? isVerified;
+  final String verifiedSuffixKey;
+  final String unverifiedSuffixKey;
 
-  const RequestorHeader({this.requestor, this.isVerified});
+  const RequestorHeader({
+    this.requestor,
+    this.isVerified,
+    required this.verifiedSuffixKey,
+    required this.unverifiedSuffixKey,
+  });
 
   _showCredentialOptionsBottomSheet(BuildContext context) {
     return showYiviBottomSheet(
@@ -82,12 +89,10 @@ class RequestorHeader extends StatelessWidget {
 
       if (isVerified!) {
         backgroundColorOverride = theme.success.withAlpha(opacity);
-        mainTextSuffixTranslationKey =
-            "disclosure_permission.overview.requestor_verification.verified_suffix";
+        mainTextSuffixTranslationKey = verifiedSuffixKey;
       } else {
         backgroundColorOverride = theme.error.withAlpha(opacity);
-        mainTextSuffixTranslationKey =
-            "disclosure_permission.overview.requestor_verification.unverified_suffix";
+        mainTextSuffixTranslationKey = unverifiedSuffixKey;
       }
 
       // Wrap the avatar in a Stack and position the verification status indicator

--- a/yivi_core/lib/src/widgets/requestor_header.dart
+++ b/yivi_core/lib/src/widgets/requestor_header.dart
@@ -25,6 +25,15 @@ _buildRequestorAvatar({
   );
 }
 
+void _showRequestorVerificationBottomSheet(BuildContext context) {
+  showYiviBottomSheet(
+    context: context,
+    titleKey:
+        "disclosure_permission.overview.requestor_verification.bottom_sheet.title",
+    child: RequestorVerificationExplanationBottomSheet(),
+  );
+}
+
 class RequestorHeader extends StatelessWidget {
   final TrustedParty? requestor;
   final bool? isVerified;
@@ -37,15 +46,6 @@ class RequestorHeader extends StatelessWidget {
     required this.verifiedSuffixKey,
     required this.unverifiedSuffixKey,
   });
-
-  _showCredentialOptionsBottomSheet(BuildContext context) {
-    return showYiviBottomSheet(
-      context: context,
-      titleKey:
-          "disclosure_permission.overview.requestor_verification.bottom_sheet.title",
-      child: RequestorVerificationExplanationBottomSheet(),
-    );
-  }
 
   @override
   Widget build(BuildContext context) {
@@ -77,7 +77,7 @@ class RequestorHeader extends StatelessWidget {
       subtitleTextWidget = Padding(
         padding: EdgeInsets.only(top: theme.defaultSpacing),
         child: GestureDetector(
-          onTap: () => _showCredentialOptionsBottomSheet(context),
+          onTap: () => _showRequestorVerificationBottomSheet(context),
           child: TranslatedText(
             "disclosure_permission.overview.requestor_verification.explanation",
             style: theme.hyperlinkTextStyle.copyWith(
@@ -141,6 +141,95 @@ class RequestorHeader extends StatelessWidget {
       mainText: mainTextWidget,
       subtitleText: subtitleTextWidget,
       backgroundColor: backgroundColorOverride,
+    );
+  }
+}
+
+/// Header for issuance-context screens. Picks between a single
+/// [RequestorHeader] when every issuer in [issuers] shares the same id, and a
+/// [MultiIssuerBanner] when more than one distinct issuer is offering
+/// credentials. Multiple distinct issuers can only occur in IRMA sessions —
+/// OpenID4VCI sessions are always single-issuer.
+class IssuersHeader extends StatelessWidget {
+  final List<TrustedParty> issuers;
+
+  const IssuersHeader({super.key, required this.issuers})
+    : assert(issuers.length > 0, "IssuersHeader requires at least one issuer");
+
+  @override
+  Widget build(BuildContext context) {
+    final allSameId = issuers.map((i) => i.id).toSet().length == 1;
+    if (allSameId) {
+      final issuer = issuers.first;
+      return RequestorHeader(
+        requestor: issuer,
+        isVerified: issuer.verified,
+        verifiedSuffixKey: "issuance.requestor_verification.verified_suffix",
+        unverifiedSuffixKey:
+            "issuance.requestor_verification.unverified_suffix",
+      );
+    }
+    return MultiIssuerBanner(
+      isAllVerified: issuers.every((i) => i.verified),
+    );
+  }
+}
+
+/// Card shown when several distinct issuers are offering credentials in a
+/// single IRMA issuance session. Mirrors [RequestorHeader]'s card/color style
+/// but uses a collective icon instead of a single avatar, since there is no
+/// single party to attribute the request to.
+class MultiIssuerBanner extends StatelessWidget {
+  final bool isAllVerified;
+
+  const MultiIssuerBanner({super.key, required this.isAllVerified});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = IrmaTheme.of(context);
+    final mainTextDefaultStyle = theme.themeData.textTheme.bodyMedium!;
+    const int opacity = 40;
+
+    final boldKey = isAllVerified
+        ? "issuance.requestor_verification.multi_issuer_verified_bold"
+        : "issuance.requestor_verification.multi_issuer_unverified_bold";
+    final suffixKey = isAllVerified
+        ? "issuance.requestor_verification.multi_issuer_verified_suffix"
+        : "issuance.requestor_verification.multi_issuer_unverified_suffix";
+
+    final backgroundColor = (isAllVerified ? theme.success : theme.error)
+        .withAlpha(opacity);
+
+    return _RequestorHeaderBase(
+      backgroundColor: backgroundColor,
+      avatar: Icon(Icons.groups, size: 48, color: theme.neutralExtraDark),
+      mainText: RichText(
+        key: const Key("multi_issuer_banner_main_text"),
+        text: TextSpan(
+          children: [
+            TextSpan(
+              text: FlutterI18n.translate(context, boldKey),
+              style: mainTextDefaultStyle.copyWith(fontWeight: FontWeight.bold),
+            ),
+            TextSpan(
+              text: FlutterI18n.translate(context, suffixKey),
+              style: mainTextDefaultStyle,
+            ),
+          ],
+        ),
+      ),
+      subtitleText: Padding(
+        padding: EdgeInsets.only(top: theme.defaultSpacing),
+        child: GestureDetector(
+          onTap: () => _showRequestorVerificationBottomSheet(context),
+          child: TranslatedText(
+            "disclosure_permission.overview.requestor_verification.explanation",
+            style: theme.hyperlinkTextStyle.copyWith(
+              fontWeight: FontWeight.normal,
+            ),
+          ),
+        ),
+      ),
     );
   }
 }

--- a/yivi_core/test/issuers_header_test.dart
+++ b/yivi_core/test/issuers_header_test.dart
@@ -1,0 +1,171 @@
+import "package:flutter/material.dart";
+import "package:flutter_i18n/flutter_i18n_delegate.dart";
+import "package:flutter_i18n/loaders/file_translation_loader.dart";
+import "package:flutter_localizations/flutter_localizations.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:yivi_core/src/models/schemaless/schemaless_events.dart";
+import "package:yivi_core/src/models/translated_value.dart";
+import "package:yivi_core/src/theme/theme.dart";
+import "package:yivi_core/src/widgets/requestor_header.dart";
+
+class _TestWidget extends StatelessWidget {
+  final List<TrustedParty> issuers;
+
+  const _TestWidget(this.issuers);
+
+  @override
+  Widget build(BuildContext context) => IrmaTheme(
+    builder: (_) => MaterialApp(
+      localizationsDelegates: [
+        FlutterI18nDelegate(
+          translationLoader: FileTranslationLoader(
+            basePath: "assets/locales",
+            forcedLocale: const Locale("en", "US"),
+          ),
+        ),
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      home: Scaffold(body: IssuersHeader(issuers: issuers)),
+    ),
+  );
+}
+
+TrustedParty _issuer({required String id, required bool verified}) =>
+    TrustedParty(
+      id: id,
+      name: TranslatedValue.fromString("Issuer $id"),
+      url: null,
+      parent: null,
+      verified: verified,
+    );
+
+void main() {
+  testWidgets("single verified issuer renders RequestorHeader", (tester) async {
+    await tester.pumpWidget(
+      _TestWidget([_issuer(id: "a", verified: true)]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RequestorHeader), findsOneWidget);
+    expect(find.byType(MultiIssuerBanner), findsNothing);
+    final mainText =
+        tester.widget<RichText>(
+          find.byKey(const Key("requestor_header_main_text")),
+        ).text.toPlainText();
+    expect(
+      mainText,
+      "Issuer a wants to add data to your wallet. This is a known party that has registered itself with Yivi.",
+    );
+  });
+
+  testWidgets("single unverified issuer renders RequestorHeader", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _TestWidget([_issuer(id: "a", verified: false)]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RequestorHeader), findsOneWidget);
+    expect(find.byType(MultiIssuerBanner), findsNothing);
+    final mainText =
+        tester.widget<RichText>(
+          find.byKey(const Key("requestor_header_main_text")),
+        ).text.toPlainText();
+    expect(
+      mainText,
+      "Issuer a wants to add data to your wallet. Warning: this party is not known by Yivi.",
+    );
+  });
+
+  testWidgets("multiple credentials with same issuer id collapse to one header", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _TestWidget([
+        _issuer(id: "a", verified: true),
+        _issuer(id: "a", verified: true),
+        _issuer(id: "a", verified: true),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(RequestorHeader), findsOneWidget);
+    expect(find.byType(MultiIssuerBanner), findsNothing);
+  });
+
+  testWidgets("multiple distinct issuers, all verified → MultiIssuerBanner verified", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _TestWidget([
+        _issuer(id: "a", verified: true),
+        _issuer(id: "b", verified: true),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MultiIssuerBanner), findsOneWidget);
+    expect(find.byType(RequestorHeader), findsNothing);
+    final mainText =
+        tester.widget<RichText>(
+          find.byKey(const Key("multi_issuer_banner_main_text")),
+        ).text.toPlainText();
+    expect(
+      mainText,
+      "Multiple parties want to add data to your wallet. All of them are known by Yivi.",
+    );
+  });
+
+  testWidgets("multiple distinct issuers, any unverified → MultiIssuerBanner unverified", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _TestWidget([
+        _issuer(id: "a", verified: true),
+        _issuer(id: "b", verified: false),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MultiIssuerBanner), findsOneWidget);
+    expect(find.byType(RequestorHeader), findsNothing);
+    final mainText =
+        tester.widget<RichText>(
+          find.byKey(const Key("multi_issuer_banner_main_text")),
+        ).text.toPlainText();
+    expect(
+      mainText,
+      "Multiple parties want to add data to your wallet. Warning: not all of them are known by Yivi.",
+    );
+  });
+
+  testWidgets("multiple distinct issuers, all unverified → MultiIssuerBanner unverified", (
+    tester,
+  ) async {
+    await tester.pumpWidget(
+      _TestWidget([
+        _issuer(id: "a", verified: false),
+        _issuer(id: "b", verified: false),
+      ]),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(MultiIssuerBanner), findsOneWidget);
+    expect(find.byType(RequestorHeader), findsNothing);
+    final mainText =
+        tester.widget<RichText>(
+          find.byKey(const Key("multi_issuer_banner_main_text")),
+        ).text.toPlainText();
+    expect(
+      mainText,
+      "Multiple parties want to add data to your wallet. Warning: not all of them are known by Yivi.",
+    );
+  });
+
+  test("empty issuers list throws assertion", () {
+    expect(() => IssuersHeader(issuers: const []), throwsAssertionError);
+  });
+}


### PR DESCRIPTION
Give the user some feedback about what kind of issuer they're dealing with. 
For IRMA sessions the issuer is always verified and for OpenID4VCI sessions the issuer is always unverified (for now).
This will change when we add support for trust lists for OpenID4VCI sessions.