### PR TITLE
Make openid4vci auth code flow not open browser immediately

### DIFF
--- a/yivi_app/integration_test/openid4vci_authcode_issuance_test.dart
+++ b/yivi_app/integration_test/openid4vci_authcode_issuance_test.dart
@@ -129,9 +129,11 @@ Future<void> testIssueEmailOpenID4VCIAuthCode(
   irmaBinding.repository.startTestSessionFromUrl(offer.uri);
   final sessionId = await newSessionFuture;
 
-  // The wallet auto-launches the browser when the session enters
-  // requestAuthorizationCode. Wait for openID4VCIState to be populated, then
-  // dispatch the synthetic deep-link that mimics the browser redirect.
+  // Wait for openID4VCIState to be populated and fetch the synthetic auth
+  // code before driving the pending screen — the body string mentions the
+  // issuer by name (interpolated), so we can verify the screen surfaces it
+  // without a RequestorHeader. The issuer name appears in both the body
+  // text and the credential card, hence findsAtLeast(1).
   final session = await irmaBinding.repository
       .getSessionState(sessionId)
       .firstWhere((s) => s.openID4VCIState != null);
@@ -140,6 +142,12 @@ Future<void> testIssueEmailOpenID4VCIAuthCode(
     issuerState: offer.issuerState,
     walletState: walletState,
   );
+
+  await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
+  expect(find.text("Email Credential (SD-JWT)"), findsOneWidget);
+  expect(find.textContaining("AuthCode Issuer"), findsAtLeast(1));
+  await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
+
   dispatchAuthCallback(
     irmaBinding.repository,
     walletState: walletState,
@@ -229,7 +237,10 @@ Future<void> testIssueOrganizationOpenID4VCIAuthCode(
     walletState: walletState,
   );
 
-  // Wallet auto-launched the browser; dispatch the synthetic redirect.
+  // Confirm and launch via the pending screen, then dispatch the synthetic
+  // redirect to mimic the browser callback.
+  await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
+  await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
   dispatchAuthCallback(
     irmaBinding.repository,
     walletState: walletState,
@@ -295,8 +306,9 @@ Future<void> testDismissOnPendingScreen(
   );
   irmaBinding.repository.startTestSessionFromUrl(offer.uri);
 
-  // The wallet auto-launches the browser. Without a synthetic redirect, the
-  // session stays in requestAuthorizationCode and the pending screen renders.
+  // When the session enters requestAuthorizationCode, the pending screen is
+  // rendered awaiting the user to tap "Open browser". Without that tap, no
+  // browser launch happens and the session stays put.
   await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
 
   // Tap "Cancel" to dismiss the session directly.
@@ -339,7 +351,10 @@ Future<void> testDismissOnIssuancePermissionScreen(
     walletState: walletState,
   );
 
-  // Browser auto-launched; dispatch the synthetic redirect to advance state.
+  // Confirm and launch via the pending screen, then dispatch the synthetic
+  // redirect to advance state.
+  await tester.waitFor(find.byType(OpenID4VCIAuthCodePendingScreen));
+  await tester.tapAndSettle(find.byKey(const Key("bottom_bar_primary")));
   dispatchAuthCallback(
     irmaBinding.repository,
     walletState: walletState,

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -443,7 +443,7 @@
     "authorization_code": {
       "pending": {
         "title": "Daten hinzufügen",
-        "body": "{issuer} muss einige Angaben in Ihrem Browser bestätigen. Tippen Sie auf {button}, um fortzufahren. Sie kehren automatisch hierher zurück, sobald Sie fertig sind.",
+        "body": "{issuer} muss einige Angaben in Ihrem Browser bestätigen. Tippen Sie auf '{button}', um fortzufahren. Sie kehren automatisch hierher zurück, sobald Sie fertig sind.",
         "open_browser": "Browser öffnen",
         "cancel": "Abbrechen"
       }

--- a/yivi_core/assets/locales/de.json
+++ b/yivi_core/assets/locales/de.json
@@ -443,9 +443,8 @@
     "authorization_code": {
       "pending": {
         "title": "Daten hinzufügen",
-        "header": "Im Browser fortfahren",
-        "body": "Wir haben den Browser geöffnet, damit Sie die Schritte bei {issuer} abschließen können. Wenn Sie fertig sind, kehren Sie automatisch hierher zurück.",
-        "open_browser": "Browser erneut öffnen",
+        "body": "{issuer} muss einige Angaben in Ihrem Browser bestätigen. Tippen Sie auf {button}, um fortzufahren. Sie kehren automatisch hierher zurück, sobald Sie fertig sind.",
+        "open_browser": "Browser öffnen",
         "cancel": "Abbrechen"
       }
     }

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -443,9 +443,8 @@
     "authorization_code": {
       "pending": {
         "title": "Add data",
-        "header": "Continue in your browser",
-        "body": "We've opened the browser so you can complete the steps at {issuer}. When you're done, you'll return here automatically.",
-        "open_browser": "Open browser again",
+        "body": "{issuer} needs to verify some details in your browser. Tap {button} to continue. You'll return here automatically when you're done.",
+        "open_browser": "Open browser",
         "cancel": "Cancel"
       }
     }

--- a/yivi_core/assets/locales/en.json
+++ b/yivi_core/assets/locales/en.json
@@ -443,7 +443,7 @@
     "authorization_code": {
       "pending": {
         "title": "Add data",
-        "body": "{issuer} needs to verify some details in your browser. Tap {button} to continue. You'll return here automatically when you're done.",
+        "body": "{issuer} needs to verify some details in your browser. Tap '{button}' to continue. You'll return here automatically when you're done.",
         "open_browser": "Open browser",
         "cancel": "Cancel"
       }

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -443,7 +443,7 @@
     "authorization_code": {
       "pending": {
         "title": "Gegevens toevoegen",
-        "body": "{issuer} moet enkele gegevens in je browser bevestigen. Druk op {button} om door te gaan. Je komt vanzelf terug als je klaar bent.",
+        "body": "{issuer} moet enkele gegevens in je browser bevestigen. Druk op '{button}' om door te gaan. Je komt vanzelf terug als je klaar bent.",
         "open_browser": "Browser openen",
         "cancel": "Annuleren"
       }

--- a/yivi_core/assets/locales/nl.json
+++ b/yivi_core/assets/locales/nl.json
@@ -443,9 +443,8 @@
     "authorization_code": {
       "pending": {
         "title": "Gegevens toevoegen",
-        "header": "Ga verder in je browser",
-        "body": "We hebben de browser geopend zodat je de stappen bij {issuer} kunt voltooien. Als je klaar bent kom je automatisch terug.",
-        "open_browser": "Browser opnieuw openen",
+        "body": "{issuer} moet enkele gegevens in je browser bevestigen. Druk op {button} om door te gaan. Je komt vanzelf terug als je klaar bent.",
+        "open_browser": "Browser openen",
         "cancel": "Annuleren"
       }
     }

--- a/yivi_core/go.mod
+++ b/yivi_core/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.7
 require (
 	github.com/go-errors/errors v1.4.2
 	github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750
-	github.com/privacybydesign/irmago v0.19.3-0.20260601143344-6c00faf32aad
+	github.com/privacybydesign/irmago v0.19.3-0.20260603140547-5911442a1bbe
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/mobile v0.0.0-20260120165949-40bd9ace6ce4
 )

--- a/yivi_core/go.mod
+++ b/yivi_core/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.7
 require (
 	github.com/go-errors/errors v1.4.2
 	github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750
-	github.com/privacybydesign/irmago v0.19.3-0.20260603140547-5911442a1bbe
+	github.com/privacybydesign/irmago v0.19.3-0.20260604130346-27d8b581cf33
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/mobile v0.0.0-20260120165949-40bd9ace6ce4
 )

--- a/yivi_core/go.sum
+++ b/yivi_core/go.sum
@@ -221,8 +221,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750 h1:3RuYOQTlArQ6Uw2TgySusmZGluP+18WdQL56YSfkM3Q=
 github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750/go.mod h1:QZI8hX8Ff2GfZ7UJuxyWw3nAGgt2s5+U4hxY6rmwQvs=
-github.com/privacybydesign/irmago v0.19.3-0.20260601143344-6c00faf32aad h1:cOBQAZ8wrHiiqQRTKr6Fw2NVfk7qUVXTiEdI+crftfo=
-github.com/privacybydesign/irmago v0.19.3-0.20260601143344-6c00faf32aad/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
+github.com/privacybydesign/irmago v0.19.3-0.20260603140547-5911442a1bbe h1:pi8UGn67tBneEa/eGJH0oq4CXzI6k/t7pRzpVFYkYu4=
+github.com/privacybydesign/irmago v0.19.3-0.20260603140547-5911442a1bbe/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/yivi_core/go.sum
+++ b/yivi_core/go.sum
@@ -223,6 +223,8 @@ github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750 h1:3RuYOQTlAr
 github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750/go.mod h1:QZI8hX8Ff2GfZ7UJuxyWw3nAGgt2s5+U4hxY6rmwQvs=
 github.com/privacybydesign/irmago v0.19.3-0.20260603140547-5911442a1bbe h1:pi8UGn67tBneEa/eGJH0oq4CXzI6k/t7pRzpVFYkYu4=
 github.com/privacybydesign/irmago v0.19.3-0.20260603140547-5911442a1bbe/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
+github.com/privacybydesign/irmago v0.19.3-0.20260604130346-27d8b581cf33 h1:4UYJzgJJNB0otrcgNS5qtsGTyxTjCGpUofH9SMywFqQ=
+github.com/privacybydesign/irmago v0.19.3-0.20260604130346-27d8b581cf33/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/yivi_core/lib/src/screens/session/session_screen.dart
+++ b/yivi_core/lib/src/screens/session/session_screen.dart
@@ -77,9 +77,8 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
   /// Whether the user has acknowledged the issuance-during-disclosure completion.
   bool _issueDuringDisclosureAcknowledged = false;
 
-  /// True after the OID4VCI side effect (auto-grant or browser launch) has
-  /// fired for the current session, so we don't fire it again on rebuilds or
-  /// when the user returns from a cancelled browser flow.
+  /// True after the OID4VCI pre-auth auto-grant has fired for the current
+  /// session, so we don't fire it again on rebuilds.
   bool _autoTriggeredForOpenID4VCI = false;
 
   /// Tracks the most recent non-null `remainingTxCodeAttempts`. When the
@@ -160,9 +159,6 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
           session.transactionCodeParameters == null) {
         _autoTriggeredForOpenID4VCI = true;
         _grantPreAuthorizedCode(session, transactionCode: null);
-      } else if (session.status == SessionStatus.requestAuthorizationCode) {
-        _autoTriggeredForOpenID4VCI = true;
-        _repo.authenticateOpenID4VCI(session.authorizationRequestUrl!);
       }
     });
 
@@ -323,10 +319,12 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
       return _buildLoadingScreen(session);
     }
 
-    // requestAuthorizationCode: browser auto-opened via ref.listen. This
-    // screen is shown when the user returns to the app without completing.
+    // requestAuthorizationCode: the user must tap "Open browser" on this
+    // screen to launch the issuer flow. Shown on first entry and whenever
+    // the user returns to the app without completing the browser flow.
     return OpenID4VCIAuthCodePendingScreen(
-      issuer: session.offeredCredentialTypes!.first.issuer,
+      requestor: session.requestor,
+      offeredCredentialTypes: session.offeredCredentialTypes!,
       onOpenBrowser: () =>
           _repo.authenticateOpenID4VCI(session.authorizationRequestUrl!),
       onDismiss: _dismissSession,

--- a/yivi_core/lib/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart
+++ b/yivi_core/lib/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart
@@ -10,10 +10,10 @@ import "../../../widgets/irma_bottom_bar.dart";
 import "../../../widgets/irma_quote.dart";
 import "session_scaffold.dart";
 
-class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
+class OpenID4VCIAuthCodePendingScreen extends StatefulWidget {
   final TrustedParty requestor;
   final List<CredentialDescriptor> offeredCredentialTypes;
-  final VoidCallback onOpenBrowser;
+  final Future<void> Function() onOpenBrowser;
   final VoidCallback onDismiss;
 
   const OpenID4VCIAuthCodePendingScreen({
@@ -25,9 +25,28 @@ class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
   });
 
   @override
+  State<OpenID4VCIAuthCodePendingScreen> createState() =>
+      _OpenID4VCIAuthCodePendingScreenState();
+}
+
+class _OpenID4VCIAuthCodePendingScreenState
+    extends State<OpenID4VCIAuthCodePendingScreen> {
+  bool _launching = false;
+
+  Future<void> _handleOpenBrowser() async {
+    if (_launching) return;
+    setState(() => _launching = true);
+    try {
+      await widget.onOpenBrowser();
+    } finally {
+      if (mounted) setState(() => _launching = false);
+    }
+  }
+
+  @override
   Widget build(BuildContext context) {
     final theme = IrmaTheme.of(context);
-    final issuerName = getTranslation(context, requestor.name);
+    final issuerName = getTranslation(context, widget.requestor.name);
     final buttonLabel = FlutterI18n.translate(
       context,
       "issuance.authorization_code.pending.open_browser",
@@ -35,15 +54,15 @@ class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
 
     return SessionScaffold(
       appBarTitle: "issuance.authorization_code.pending.title",
-      onDismiss: onDismiss,
+      onDismiss: widget.onDismiss,
       bottomNavigationBar: IrmaBottomBar(
         primaryButtonLabel: buttonLabel,
-        onPrimaryPressed: onOpenBrowser,
+        onPrimaryPressed: _launching ? null : _handleOpenBrowser,
         secondaryButtonLabel: FlutterI18n.translate(
           context,
           "issuance.authorization_code.pending.cancel",
         ),
-        onSecondaryPressed: onDismiss,
+        onSecondaryPressed: widget.onDismiss,
       ),
       body: ListView(
         padding: EdgeInsets.only(
@@ -65,7 +84,7 @@ class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
               ),
             ),
           ),
-          ...offeredCredentialTypes.map(
+          ...widget.offeredCredentialTypes.map(
             (descriptor) => Padding(
               padding: EdgeInsets.only(bottom: theme.defaultSpacing),
               child: YiviCredentialCard.fromDescriptor(

--- a/yivi_core/lib/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart
+++ b/yivi_core/lib/src/screens/session/widgets/openid4vci_authcode_pending_screen.dart
@@ -1,21 +1,25 @@
 import "package:flutter/material.dart";
 import "package:flutter_i18n/flutter_i18n.dart";
 
+import "../../../models/schemaless/credential_store.dart";
 import "../../../models/schemaless/schemaless_events.dart";
 import "../../../theme/theme.dart";
 import "../../../util/language.dart";
+import "../../../widgets/credential_card/yivi_credential_card.dart";
 import "../../../widgets/irma_bottom_bar.dart";
-import "../../../widgets/translated_text.dart";
+import "../../../widgets/irma_quote.dart";
 import "session_scaffold.dart";
 
 class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
-  final TrustedParty issuer;
+  final TrustedParty requestor;
+  final List<CredentialDescriptor> offeredCredentialTypes;
   final VoidCallback onOpenBrowser;
   final VoidCallback onDismiss;
 
   const OpenID4VCIAuthCodePendingScreen({
     super.key,
-    required this.issuer,
+    required this.requestor,
+    required this.offeredCredentialTypes,
     required this.onOpenBrowser,
     required this.onDismiss,
   });
@@ -23,16 +27,17 @@ class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = IrmaTheme.of(context);
-    final issuerName = getTranslation(context, issuer.name);
+    final issuerName = getTranslation(context, requestor.name);
+    final buttonLabel = FlutterI18n.translate(
+      context,
+      "issuance.authorization_code.pending.open_browser",
+    );
 
     return SessionScaffold(
       appBarTitle: "issuance.authorization_code.pending.title",
       onDismiss: onDismiss,
       bottomNavigationBar: IrmaBottomBar(
-        primaryButtonLabel: FlutterI18n.translate(
-          context,
-          "issuance.authorization_code.pending.open_browser",
-        ),
+        primaryButtonLabel: buttonLabel,
         onPrimaryPressed: onOpenBrowser,
         secondaryButtonLabel: FlutterI18n.translate(
           context,
@@ -40,28 +45,37 @@ class OpenID4VCIAuthCodePendingScreen extends StatelessWidget {
         ),
         onSecondaryPressed: onDismiss,
       ),
-      body: SafeArea(
-        child: Padding(
-          padding: EdgeInsets.all(theme.defaultSpacing),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              SizedBox(height: theme.defaultSpacing),
-              TranslatedText(
-                "issuance.authorization_code.pending.header",
-                isHeader: true,
-                style: theme.textTheme.bodyLarge!.copyWith(
-                  color: theme.neutralExtraDark,
-                ),
-              ),
-              SizedBox(height: theme.defaultSpacing),
-              TranslatedText(
-                "issuance.authorization_code.pending.body",
-                translationParams: {"issuer": issuerName},
-              ),
-            ],
-          ),
+      body: ListView(
+        padding: EdgeInsets.only(
+          left: theme.defaultSpacing,
+          right: theme.defaultSpacing,
+          top: theme.smallSpacing,
         ),
+        children: [
+          Padding(
+            padding: EdgeInsets.symmetric(vertical: theme.smallSpacing),
+            child: IrmaQuote(
+              quote: FlutterI18n.translate(
+                context,
+                "issuance.authorization_code.pending.body",
+                translationParams: {
+                  "issuer": issuerName,
+                  "button": buttonLabel,
+                },
+              ),
+            ),
+          ),
+          ...offeredCredentialTypes.map(
+            (descriptor) => Padding(
+              padding: EdgeInsets.only(bottom: theme.defaultSpacing),
+              child: YiviCredentialCard.fromDescriptor(
+                descriptor: descriptor,
+                compact: false,
+                hideNotObtainable: true,
+              ),
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/yivi_core/lib/src/widgets/credential_card/yivi_credential_card.dart
+++ b/yivi_core/lib/src/widgets/credential_card/yivi_credential_card.dart
@@ -141,6 +141,7 @@ class YiviCredentialCard extends ConsumerWidget {
     Widget? headerTrailing,
     IrmaCardStyle style = IrmaCardStyle.normal,
     EdgeInsetsGeometry? padding,
+    bool hideNotObtainable = false,
   }) : this(
          key: key,
          credentialName: descriptor.name,
@@ -191,6 +192,7 @@ class YiviCredentialCard extends ConsumerWidget {
          style: style,
          padding: padding,
          hideFooter: true,
+         hideNotObtainable: hideNotObtainable,
        );
 
   YiviCredentialCard.fromDescriptorWithEmptyAttributeValues({

--- a/yivi_core/lib/src/widgets/credential_card/yivi_credential_card.dart
+++ b/yivi_core/lib/src/widgets/credential_card/yivi_credential_card.dart
@@ -265,6 +265,12 @@ class YiviCredentialCard extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final theme = IrmaTheme.of(context);
+    final displayName = credentialName.isNotEmpty
+        ? getTranslation(context, credentialName)
+        : (status.credentialId ?? "");
+    final displayIssuerName = issuerName.isNotEmpty
+        ? getTranslation(context, issuerName)
+        : FlutterI18n.translate(context, "ui.unknown");
 
     return IrmaCard(
       style: status.isExpired || status.revoked ? IrmaCardStyle.danger : style,
@@ -276,8 +282,8 @@ class YiviCredentialCard extends ConsumerWidget {
         children: [
           YiviCredentialCardHeader(
             compact: compact,
-            credentialName: getTranslation(context, credentialName),
-            issuerName: getTranslation(context, issuerName),
+            credentialName: displayName,
+            issuerName: displayIssuerName,
             logoPath: imagePath,
             logoImage: image,
             trailing: headerTrailing,
@@ -336,9 +342,7 @@ class YiviCredentialCard extends ConsumerWidget {
                 message: FlutterI18n.translate(
                   context,
                   "credential.not_obtainable",
-                  translationParams: {
-                    "issuerName": getTranslation(context, issuerName),
-                  },
+                  translationParams: {"issuerName": displayIssuerName},
                 ),
               ),
             ),


### PR DESCRIPTION
The app currently immediately opens the browser when the user starts the app with an auth code flow session. This can be confusing, therefore we introduce a screen telling the user what's about to happen and letting them open the browser themselves.