### PR TITLE
Release v7.14.0 beta 4

### DIFF
--- a/yivi_app/pubspec.yaml
+++ b/yivi_app/pubspec.yaml
@@ -2,7 +2,7 @@ name: yivi
 description: "Yivi App"
 
 # A build number cannot be reused once a build is in use on Android.
-version: 7.14.0+4194506
+version: 7.14.0+4194507
 
 publish_to: none
 

--- a/yivi_core/go.mod
+++ b/yivi_core/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.7
 require (
 	github.com/go-errors/errors v1.4.2
 	github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750
-	github.com/privacybydesign/irmago v0.19.3-0.20260604130346-27d8b581cf33
+	github.com/privacybydesign/irmago v0.19.3-0.20260608130548-6b14ee5127f0
 	github.com/sirupsen/logrus v1.9.0
 	golang.org/x/mobile v0.0.0-20260120165949-40bd9ace6ce4
 )

--- a/yivi_core/go.sum
+++ b/yivi_core/go.sum
@@ -221,10 +221,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750 h1:3RuYOQTlArQ6Uw2TgySusmZGluP+18WdQL56YSfkM3Q=
 github.com/privacybydesign/gabi v0.0.0-20221212095008-68a086907750/go.mod h1:QZI8hX8Ff2GfZ7UJuxyWw3nAGgt2s5+U4hxY6rmwQvs=
-github.com/privacybydesign/irmago v0.19.3-0.20260603140547-5911442a1bbe h1:pi8UGn67tBneEa/eGJH0oq4CXzI6k/t7pRzpVFYkYu4=
-github.com/privacybydesign/irmago v0.19.3-0.20260603140547-5911442a1bbe/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
-github.com/privacybydesign/irmago v0.19.3-0.20260604130346-27d8b581cf33 h1:4UYJzgJJNB0otrcgNS5qtsGTyxTjCGpUofH9SMywFqQ=
-github.com/privacybydesign/irmago v0.19.3-0.20260604130346-27d8b581cf33/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
+github.com/privacybydesign/irmago v0.19.3-0.20260608130548-6b14ee5127f0 h1:ipdaSqfUrHQ80lDQVu8/Bd2EWfnDapgnHlKI8D7Wqf4=
+github.com/privacybydesign/irmago v0.19.3-0.20260608130548-6b14ee5127f0/go.mod h1:xNTXPHsMwU200yBGr+FSkUCUYtf2C0Egc/nUu2XNUNg=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=

--- a/yivi_fdroid/pubspec.yaml
+++ b/yivi_fdroid/pubspec.yaml
@@ -2,7 +2,7 @@ name: yivi
 description: "Yivi App"
 
 # A build number cannot be reused once a build is in use on Android.
-version: 7.14.0+4194506
+version: 7.14.0+4194507
 
 publish_to: none
 


### PR DESCRIPTION
## Changes:
- Prefer SD-JWT VC metadata over OpenID4VCI issuer metadata
- Allow `did:jwk` for issuer/credential verification
- Pre-authorized code flow is now the default when both grants are allowed
- Browser is no longer immediately opened in authorization code flows
