### PR TITLE
ci: pre-install Android SDK Platform 35 to avoid flaky F-Droid builds

### DIFF
--- a/ci_scripts/install_android_sdk.sh
+++ b/ci_scripts/install_android_sdk.sh
@@ -57,6 +57,7 @@ sdkmanager --sdk_root="$ANDROID_HOME" \
   "cmdline-tools;latest" \
   "ndk;$ANDROID_NDK_VERSION" \
   "cmake;3.22.1" \
+  "platforms;android-35" \
   "platforms;android-36" \
   "build-tools;36.1.0"
 


### PR DESCRIPTION
## Problem

The F-Droid build jobs (`build-app-android-fdroid`) intermittently fail at the Build step with:

```
Warning: An error occurred while preparing SDK package Android SDK Platform 35: Error on ZipFile unknown archive.
> Failed to install the following SDK components:
      platforms;android-35 Android SDK Platform 35
Caused by: java.util.zip.ZipException: Archive is not a ZIP archive
"Install Android SDK Platform 35 (revision 2)" failed.
Gradle task assembleBetaRelease failed with exit code 1
```

The Gradle build requires `platforms;android-35` (a transitive dependency requirement), but `ci_scripts/install_android_sdk.sh` only pre-installs `android-36`. So every build downloads android-35 on the fly via `sdkmanager`, which is exposed to corrupt/partial-download flakes. When this hits one matrix flavor, the build fails (and, with matrix fail-fast, takes the other flavor down with it).

## Fix

Pre-install `platforms;android-35` alongside `android-36`. This is **additive** — nothing is downgraded; `compileSdkVersion` stays at 36. It just makes SDK provisioning deterministic and removes the on-demand download that causes the flake, matching the script comment about pre-installing SDKs to avoid per-build downloads.