### PR TITLE
Fix requestor header colors

### DIFF
--- a/yivi_core/lib/src/theme/theme.dart
+++ b/yivi_core/lib/src/theme/theme.dart
@@ -42,8 +42,10 @@ class IrmaThemeData {
 
   // Communicating colors
   final Color error = const Color(0xFFBD1919);
+  final Color errorSurface = const Color(0xFFF5DBDB);
   final Color warning = const Color(0xFFEBA73B);
   final Color success = const Color(0xFF00973A);
+  final Color successSurface = const Color(0xFFD7EFE0);
   final Color link = const Color(0xFF1D4E89);
   final Color danger = const Color(0xffEABEBE);
 

--- a/yivi_core/lib/src/widgets/requestor_header.dart
+++ b/yivi_core/lib/src/widgets/requestor_header.dart
@@ -70,7 +70,6 @@ class RequestorHeader extends StatelessWidget {
     if (isVerified != null) {
       final mainTextDefaultStyle = theme.themeData.textTheme.bodyMedium;
       String mainTextSuffixTranslationKey;
-      const int opacity = 40;
 
       // Set the subtitleTextWidget to a link
       subtitleTextWidget = Padding(
@@ -87,11 +86,11 @@ class RequestorHeader extends StatelessWidget {
       );
 
       if (isVerified!) {
-        backgroundColorOverride = theme.success.withAlpha(opacity);
+        backgroundColorOverride = theme.successSurface;
         mainTextSuffixTranslationKey =
             "disclosure_permission.overview.requestor_verification.verified_suffix";
       } else {
-        backgroundColorOverride = theme.error.withAlpha(opacity);
+        backgroundColorOverride = theme.errorSurface;
         mainTextSuffixTranslationKey =
             "disclosure_permission.overview.requestor_verification.unverified_suffix";
       }


### PR DESCRIPTION
When we added a drop shadow to the requestor header, the color slightly changed compared to what it used to be due to the opacity of the background letting the shadow color blend in.
