### PR TITLE
Fix session replay bug on Android

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -36,12 +36,18 @@ lane :unit_test do
   # Android native (JVM) unit tests, including the deep-link session-replay
   # regression test (#568). The yivi_core plugin module compiles against the
   # irmagobridge AAR, so build it first, then run the unit tests through the host
-  # app's Gradle project (which is where Flutter generates the Gradle wrapper and
-  # registers the :yivi_core plugin module).
+  # app's Gradle project (which is where Flutter registers the :yivi_core plugin
+  # module).
+  #
+  # The Gradle wrapper (gradlew + gradle-wrapper.jar) is gitignored, so it does not
+  # exist on a clean checkout — only a Flutter Android build injects it. `flutter
+  # build apk --config-only` runs Flutter's gradle-wrapper injection (and a pub get)
+  # without doing a full compile, so it is enough to materialise ./gradlew. A flavor
+  # is required because the app declares product flavors with no default.
   aar = File.expand_path("../yivi_core/android/irmagobridge/irmagobridge.aar", __dir__)
   android_build_irmagobridge() unless File.exist?(aar)
   Dir.chdir("../yivi_app") do
-    sh("flutter", "pub", "get")
+    sh("flutter", "build", "apk", "--config-only", "--flavor", "alpha")
     Dir.chdir("./android") do
       sh("./gradlew", ":yivi_core:testDebugUnitTest")
     end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -32,6 +32,20 @@ lane :unit_test do
   Dir.chdir("../yivi_core") do
     sh("flutter", "test")
   end
+
+  # Android native (JVM) unit tests, including the deep-link session-replay
+  # regression test (#568). The yivi_core plugin module compiles against the
+  # irmagobridge AAR, so build it first, then run the unit tests through the host
+  # app's Gradle project (which is where Flutter generates the Gradle wrapper and
+  # registers the :yivi_core plugin module).
+  aar = File.expand_path("../yivi_core/android/irmagobridge/irmagobridge.aar", __dir__)
+  android_build_irmagobridge() unless File.exist?(aar)
+  Dir.chdir("../yivi_app") do
+    sh("flutter", "pub", "get")
+    Dir.chdir("./android") do
+      sh("./gradlew", ":yivi_core:testDebugUnitTest")
+    end
+  end
 end
 
 lane :android_build do |options|

--- a/yivi_core/android/build.gradle
+++ b/yivi_core/android/build.gradle
@@ -56,7 +56,8 @@ android {
     }
 
     dependencies {
-        testImplementation("org.jetbrains.kotlin:kotlin-test")
+        testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+        testRuntimeOnly("org.junit.platform:junit-platform-launcher")
         testImplementation("org.mockito:mockito-core:5.0.0")
 
         implementation files('irmagobridge/irmagobridge.aar')

--- a/yivi_core/android/src/main/java/foundation/privacybydesign/yivi_core/YiviCorePlugin.java
+++ b/yivi_core/android/src/main/java/foundation/privacybydesign/yivi_core/YiviCorePlugin.java
@@ -108,7 +108,16 @@ public class YiviCorePlugin implements FlutterPlugin, ActivityAware, PluginRegis
 
     private void maybeCreateBridge() {
         if (bridge == null && channel != null && activity != null && applicationContext != null) {
-            bridge = new IrmaMobileBridge(applicationContext, activity, channel, activity.getIntent().getData());
+            Intent launchIntent = activity.getIntent();
+            Uri data = launchIntent.getData();
+            // When the user relaunches the app from the recents list — or Android
+            // restores the task after a process kill — the original launching intent
+            // is replayed with FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY set. Drop the deep
+            // link in that case so a stale session URL isn't re-fired as a new session.
+            if ((launchIntent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
+                data = null;
+            }
+            bridge = new IrmaMobileBridge(applicationContext, activity, channel, data);
             channel.setMethodCallHandler(bridge);
         }
     }

--- a/yivi_core/android/src/main/java/foundation/privacybydesign/yivi_core/YiviCorePlugin.java
+++ b/yivi_core/android/src/main/java/foundation/privacybydesign/yivi_core/YiviCorePlugin.java
@@ -109,16 +109,26 @@ public class YiviCorePlugin implements FlutterPlugin, ActivityAware, PluginRegis
     private void maybeCreateBridge() {
         if (bridge == null && channel != null && activity != null && applicationContext != null) {
             Intent launchIntent = activity.getIntent();
-            Uri data = launchIntent.getData();
-            // When the user relaunches the app from the recents list — or Android
-            // restores the task after a process kill — the original launching intent
-            // is replayed with FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY set. Drop the deep
-            // link in that case so a stale session URL isn't re-fired as a new session.
-            if ((launchIntent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0) {
-                data = null;
-            }
+            Uri data = shouldDropDeepLink(launchIntent) ? null : launchIntent.getData();
             bridge = new IrmaMobileBridge(applicationContext, activity, channel, data);
             channel.setMethodCallHandler(bridge);
         }
+    }
+
+    /**
+     * Decides whether the deep link carried by the launching intent must be ignored.
+     *
+     * <p>When the user relaunches the app from the recents list — or Android restores
+     * the task after a process kill — the original launching intent is replayed with
+     * {@link Intent#FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY} set. In that case the deep
+     * link has already been consumed, so re-firing it would replay a stale session URL
+     * as a brand new session (the bug fixed in #568). A genuine new deep link arrives
+     * without this flag (via {@code onNewIntent}), so it is left untouched.
+     *
+     * <p>Pure function of the intent's flags; extracted so the regression can be unit
+     * tested without an Activity lifecycle.
+     */
+    static boolean shouldDropDeepLink(Intent launchIntent) {
+        return (launchIntent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) != 0;
     }
 }

--- a/yivi_core/android/src/main/java/foundation/privacybydesign/yivi_core/irma_mobile_bridge/IrmaMobileBridge.java
+++ b/yivi_core/android/src/main/java/foundation/privacybydesign/yivi_core/irma_mobile_bridge/IrmaMobileBridge.java
@@ -83,6 +83,10 @@ public class IrmaMobileBridge implements MethodCallHandler, irmagobridge.IrmaMob
         if (initialURL != null) {
           channel.invokeMethod("HandleURLEvent",
             String.format("{\"url\": \"%s\", \"isInitialURL\": true}", initialURL));
+          initialURL = null;
+          // Drop the launching intent's data so a later maybeCreateBridge() — e.g.,
+          // after a configuration change — doesn't read the same URL and replay it.
+          activity.setIntent(new Intent());
         }
 
         break;

--- a/yivi_core/android/src/test/kotlin/foundation/privacybydesign/yivi_core/YiviCorePluginTest.kt
+++ b/yivi_core/android/src/test/kotlin/foundation/privacybydesign/yivi_core/YiviCorePluginTest.kt
@@ -1,27 +1,73 @@
 package foundation.privacybydesign.yivi_core
 
-import io.flutter.plugin.common.MethodCall
-import io.flutter.plugin.common.MethodChannel
+import android.content.Intent
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
 import org.mockito.Mockito
-import kotlin.test.Test
 
-/*
- * This demonstrates a simple unit test of the Kotlin portion of this plugin's implementation.
+/**
+ * Regression test for the Android deep-link session-replay bug (#568).
  *
- * Once you have built the plugin's example app, you can run these tests from the command
- * line by running `./gradlew testDebugUnitTest` in the `example/android/` directory, or
- * you can run them directly from IDEs that support JUnit such as Android Studio.
+ * Before the fix, the launching intent's deep link was replayed on every bridge
+ * (re)creation. When Android relaunches the app from recents — or restores the task
+ * after a process kill — it replays the original intent with
+ * [Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY] set, which made a stale (already
+ * consumed) session URL fire again as a brand new session.
+ *
+ * [YiviCorePlugin.shouldDropDeepLink] is the guard that prevents this. These tests
+ * pin both branches.
  */
-
 internal class YiviCorePluginTest {
+    private fun intentWithFlags(flags: Int): Intent {
+        val intent = Mockito.mock(Intent::class.java)
+        Mockito.`when`(intent.flags).thenReturn(flags)
+        return intent
+    }
+
     @Test
-    fun onMethodCall_getPlatformVersion_returnsExpectedValue() {
-        val plugin = YiviCorePlugin()
+    fun shouldDropDeepLink_dropsLinkWhenLaunchedFromHistory() {
+        val intent = intentWithFlags(Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY)
 
-        val call = MethodCall("getPlatformVersion", null)
-        val mockResult: MethodChannel.Result = Mockito.mock(MethodChannel.Result::class.java)
-        plugin.onMethodCall(call, mockResult)
+        assertTrue(
+            YiviCorePlugin.shouldDropDeepLink(intent),
+            "A deep link replayed from recents/history must be dropped to avoid a stale session replay",
+        )
+    }
 
-        Mockito.verify(mockResult).success("Android " + android.os.Build.VERSION.RELEASE)
+    @Test
+    fun shouldDropDeepLink_dropsLinkWhenHistoryFlagCombinedWithOtherFlags() {
+        val intent = intentWithFlags(
+            Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY or
+                Intent.FLAG_ACTIVITY_NEW_TASK or
+                Intent.FLAG_ACTIVITY_SINGLE_TOP,
+        )
+
+        assertTrue(
+            YiviCorePlugin.shouldDropDeepLink(intent),
+            "The history flag must be detected even when other intent flags are set",
+        )
+    }
+
+    @Test
+    fun shouldDropDeepLink_keepsLinkForFreshLaunch() {
+        val intent = intentWithFlags(0)
+
+        assertFalse(
+            YiviCorePlugin.shouldDropDeepLink(intent),
+            "A genuine deep-link launch (no history flag) must be kept",
+        )
+    }
+
+    @Test
+    fun shouldDropDeepLink_keepsLinkForOtherFlagsWithoutHistory() {
+        val intent = intentWithFlags(
+            Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_SINGLE_TOP,
+        )
+
+        assertFalse(
+            YiviCorePlugin.shouldDropDeepLink(intent),
+            "Unrelated intent flags must not be mistaken for a replay from history",
+        )
     }
 }


### PR DESCRIPTION
## Summary

Stops the Android bridge from replaying a stale deep link as a new session every time the user relaunches the app. Symptom: users (sporadically) see the previous session's error screen — most visibly an `openid4vp: authorization request returned HTTP 404` — immediately after opening the app, with no QR scan or link tap of their own.

## Root cause

The Android plugin always reads the launching deep link from `activity.getIntent().getData()` and replays it as a `HandleURLEvent` on every `AppReadyEvent`:

```java
// YiviCorePlugin.maybeCreateBridge — runs on every attach/reattach
bridge = new IrmaMobileBridge(applicationContext, activity, channel,
                              activity.getIntent().getData());
```

`Activity.getIntent()` returns the *launching* intent for the entire lifetime of the activity, and Android preserves that intent across process kills when the task stays in recents. Combined with `android:launchMode="singleTask"`, this means:

1. User taps a deep link → activity starts with `intent.data` = the URL.
2. Bridge fires `HandleURLEvent` → openid4vp session → the verifier's `request_uri` has expired → 404 → error screen.
3. User backgrounds or kills the app.
4. User reopens via the launcher icon or recents → Android restores the task with the *same* launching intent.
5. Bridge re-reads `getIntent().getData()` → fires the same expired URL → same 404.

There was no guard for `Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` (Android sets this flag specifically to signal "launched from recents, treat the data as already consumed"), and `initialURL` / the activity intent were never cleared after the first replay.

## What this PR changes

Two small, layered guards:

- **`YiviCorePlugin.maybeCreateBridge`** — when the launching intent has `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` set, pass `null` to the bridge instead of the URL. This covers the cross-process-restart case (re-launch from recents, restoration after OOM kill).
- **`IrmaMobileBridge` (AppReadyEvent handler)** — after firing the initial-URL event once, null `initialURL` and call `activity.setIntent(new Intent())`. This covers re-attachments within the same activity lifetime (e.g., configuration changes routing through `onReattachedToActivityForConfigChanges`).

Together these mean: an initial deep link can fire `HandleURLEvent` at most once per actual user action. Subsequent re-launches that aren't a fresh URL tap see no URL.

## Why this fixes it

The replay loop required `activity.getIntent().getData()` to keep returning the same URL across bridge re-creations. After this change:
- A relaunch from recents takes the `FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY` early-out → no URL stored → no replay.
- Any same-activity bridge re-creation (config change) reads a blank intent that we cleared after first fire → no URL stored → no replay.
- A legitimate new deep link still arrives via `onNewIntent`, which is untouched.

iOS is unaffected: the plugin already only stores `initialURL` on literal URL launches (`didFinishLaunchingWithOptions` / `application(open:url:)`), not on resume — so it doesn't have the equivalent bug.
