### PR TITLE
Disregard client return URL on second-device sessions (#656)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Scanning a desktop QR code with the phone's camera app is again treated as a second-device session instead of running the same-device return flow
+- On a second-device session, the relying party's client return URL is no longer opened in a browser on the phone (the browser session lives on the other device); the wallet confirms success locally instead. A `tel:` return URL still opens the phone dialer.
 
 ## [8.1.1] - 2026-07-14
 ### Fixed

--- a/yivi_app/integration_test/disclosure_session/disclosure_session_special_scenarios_test.dart
+++ b/yivi_app/integration_test/disclosure_session/disclosure_session_special_scenarios_test.dart
@@ -17,6 +17,7 @@ import "special_scenarios/nullables.dart";
 import "special_scenarios/random_blind.dart";
 import "special_scenarios/return_url_https_external.dart";
 import "special_scenarios/return_url_https_inapp.dart";
+import "special_scenarios/return_url_second_device.dart";
 import "special_scenarios/revocation.dart";
 import "special_scenarios/signing.dart";
 
@@ -111,6 +112,28 @@ void main() {
       testWidgets(
         "return-url-https-inapp",
         (tester) => returnUrlHttpsInAppTest(
+          tester,
+          irmaBinding,
+          externalLaunches: externalLaunches,
+          inAppLaunches: inAppLaunches,
+        ),
+      );
+
+      // Second-device + https clientReturnUrl → disregarded, no browser opened
+      testWidgets(
+        "return-url-second-device-external",
+        (tester) => returnUrlSecondDeviceExternalTest(
+          tester,
+          irmaBinding,
+          externalLaunches: externalLaunches,
+          inAppLaunches: inAppLaunches,
+        ),
+      );
+
+      // Second-device + https?inapp=true clientReturnUrl → disregarded
+      testWidgets(
+        "return-url-second-device-inapp",
+        (tester) => returnUrlSecondDeviceInAppTest(
           tester,
           irmaBinding,
           externalLaunches: externalLaunches,

--- a/yivi_app/integration_test/disclosure_session/special_scenarios/return_url_https_external.dart
+++ b/yivi_app/integration_test/disclosure_session/special_scenarios/return_url_https_external.dart
@@ -33,7 +33,12 @@ Future<void> returnUrlHttpsExternalTest(
        }
       ''';
 
-  await irmaBinding.repository.startTestSession(sessionRequest);
+  // Same-device: the browser that started the session is on this phone, so the
+  // client return URL is opened here on success.
+  await irmaBinding.repository.startTestSession(
+    sessionRequest,
+    continueOnSecondDevice: false,
+  );
   await evaluateIntroduction(tester);
 
   await tester.tapAndSettle(find.text("Share data"));

--- a/yivi_app/integration_test/disclosure_session/special_scenarios/return_url_https_inapp.dart
+++ b/yivi_app/integration_test/disclosure_session/special_scenarios/return_url_https_inapp.dart
@@ -33,7 +33,12 @@ Future<void> returnUrlHttpsInAppTest(
        }
       ''';
 
-  await irmaBinding.repository.startTestSession(sessionRequest);
+  // Same-device: the browser that started the session is on this phone, so the
+  // in-app client return URL is opened here on success.
+  await irmaBinding.repository.startTestSession(
+    sessionRequest,
+    continueOnSecondDevice: false,
+  );
   await evaluateIntroduction(tester);
 
   await tester.tapAndSettle(find.text("Share data"));

--- a/yivi_app/integration_test/disclosure_session/special_scenarios/return_url_second_device.dart
+++ b/yivi_app/integration_test/disclosure_session/special_scenarios/return_url_second_device.dart
@@ -1,0 +1,81 @@
+import "package:flutter_test/flutter_test.dart";
+
+import "../../helpers/helpers.dart";
+import "../../helpers/issuance_helpers.dart";
+import "../../irma_binding.dart";
+import "../../util.dart";
+import "../disclosure_helpers.dart";
+
+// On a second-device session (QR shown on another device) the browser that
+// started the session lives on that other device and honours the client return
+// URL there. The wallet must therefore NOT open the return URL on the phone —
+// it confirms success locally instead. See issue #656.
+
+Future<void> _runDisregardTest(
+  WidgetTester tester,
+  IntegrationTestIrmaBinding irmaBinding, {
+  required String returnUrl,
+  required List<String> externalLaunches,
+  required List<String> inAppLaunches,
+}) async {
+  await pumpAndUnlockApp(tester, irmaBinding.repository);
+
+  await issueEmailAddress(tester, irmaBinding);
+  await tester.tapAndSettle(find.text("OK"));
+
+  final sessionRequest =
+      '''
+       {
+          "@context": "https://irma.app/ld/request/disclosure/v2",
+          "disclose": [
+            [
+              [ "irma-demo.sidn-pbdf.email.email" ]
+            ]
+          ],
+          "clientReturnUrl": "$returnUrl"
+       }
+      ''';
+
+  // Second-device is the default for test sessions; this is the case #656 is
+  // about, so we rely on that default rather than annotating it.
+  await irmaBinding.repository.startTestSession(sessionRequest);
+  await evaluateIntroduction(tester);
+
+  await tester.tapAndSettle(find.text("Share data"));
+  await tester.tapAndSettle(find.text("Share"));
+  await tester.pumpAndSettle();
+
+  // The return URL must be disregarded — nothing is opened on the phone.
+  expect(externalLaunches, isEmpty);
+  expect(inAppLaunches, isEmpty);
+
+  // Success is confirmed in-app instead (this also taps OK and asserts the
+  // session flow is over).
+  await evaluateFeedback(tester);
+}
+
+Future<void> returnUrlSecondDeviceExternalTest(
+  WidgetTester tester,
+  IntegrationTestIrmaBinding irmaBinding, {
+  required List<String> externalLaunches,
+  required List<String> inAppLaunches,
+}) => _runDisregardTest(
+  tester,
+  irmaBinding,
+  returnUrl: "https://example.com/done",
+  externalLaunches: externalLaunches,
+  inAppLaunches: inAppLaunches,
+);
+
+Future<void> returnUrlSecondDeviceInAppTest(
+  WidgetTester tester,
+  IntegrationTestIrmaBinding irmaBinding, {
+  required List<String> externalLaunches,
+  required List<String> inAppLaunches,
+}) => _runDisregardTest(
+  tester,
+  irmaBinding,
+  returnUrl: "https://example.com/done?inapp=true",
+  externalLaunches: externalLaunches,
+  inAppLaunches: inAppLaunches,
+);

--- a/yivi_core/lib/src/screens/session/session_screen.dart
+++ b/yivi_core/lib/src/screens/session/session_screen.dart
@@ -447,18 +447,39 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
     }
 
     final returnUrl = session.parsedClientReturnUrl;
-    if (returnUrl != null) {
-      if (returnUrl.isPhoneNumber) {
-        return CallInfoScreen(
-          otherParty: getTranslation(context, session.requestor.name),
-          onContinue: () => _openReturnUrl(
-            returnUrl,
-            alwaysExternal: true,
-            popOnSuccess: true,
-          ),
-          onCancel: _closeSession,
-        );
+
+    // A tel: return URL is device-agnostic — the phone is the device that
+    // places the call — so surface the Call-via-Yivi screen regardless of
+    // whether this is a same- or second-device session.
+    if (returnUrl != null && returnUrl.isPhoneNumber) {
+      return CallInfoScreen(
+        otherParty: getTranslation(context, session.requestor.name),
+        onContinue: () =>
+            _openReturnUrl(returnUrl, alwaysExternal: true, popOnSuccess: true),
+        onCancel: _closeSession,
+      );
+    }
+
+    // Second-device session: the result lives on the other device, whose
+    // browser started the session and honours any browser-kind return URL
+    // there. Confirm success locally and do NOT open a browser on the phone —
+    // opening it here would be a pointless redirect on the wrong device.
+    // (tel: is handled above; it stays device-agnostic.)
+    if (session.continueOnSecondDevice) {
+      if (session.type == .issuance) {
+        return IssuanceSuccessScreen(onDismiss: (_) => pop());
       }
+      return DisclosureFeedbackScreen(
+        feedbackType: .success,
+        isSignatureSession: session.type == .signature,
+        otherParty: getTranslation(context, session.requestor.name),
+        onDismiss: (_) => pop(),
+      );
+    }
+
+    // Same-device session with a browser return URL (external / in-app): hand
+    // the user back to where they started by opening it.
+    if (returnUrl != null) {
       if (_returnUrlError != null) {
         return _buildError(_returnUrlError!);
       }
@@ -485,20 +506,6 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
         });
       }
       return _buildLoadingScreen(session);
-    }
-
-    // Multi-device session: result lives on the other device, so just confirm
-    // success here.
-    if (session.continueOnSecondDevice) {
-      if (session.type == .issuance) {
-        return IssuanceSuccessScreen(onDismiss: (_) => pop());
-      }
-      return DisclosureFeedbackScreen(
-        feedbackType: .success,
-        isSignatureSession: session.type == .signature,
-        otherParty: getTranslation(context, session.requestor.name),
-        onDismiss: (_) => pop(),
-      );
     }
 
     // Same-device session: hand the user back to the calling app. iOS lacks a
@@ -532,6 +539,9 @@ class _SessionScreenState extends ConsumerState<SessionScreen> {
     final shouldSilentReopen =
         returnUrl != null &&
         !returnUrl.isPhoneNumber &&
+        // On a second-device session the browser lives on the other device;
+        // reopening the return URL on the phone would be a pointless redirect.
+        session?.continueOnSecondDevice != true &&
         session?.error?.errorType != "clientReturnUrl" &&
         _returnUrlError?.errorType != "clientReturnUrl" &&
         !wasInAppLaunched;


### PR DESCRIPTION
## Problem

Fixes #656.

At session finish the wallet opened the relying party's `clientReturnUrl` in a
browser **on the phone** even for second-device sessions (QR shown on another
device). There the browser session lives on the *other* device — which honours
the return URL itself — so opening it on the phone is a pointless, surprising
redirect. `SessionScreen._buildSuccess` checked the return URL *before*
`continueOnSecondDevice`, so the return URL always won.

## Fix

Reorder `_buildSuccess` so that:

1. a `tel:` return URL still shows the Call-via-Yivi screen — device-agnostic,
   the phone is the device that places the call;
2. a **second-device** session then confirms success locally and does **not**
   open the browser;
3. a **same-device** session opens the return URL as before.

Also gate `_closeSession`'s silent reopen on `!continueOnSecondDevice`, so a
failed/closed second-device session doesn't bounce the phone to a browser either.

| Session | external / in-app return URL | `tel:` |
| --- | --- | --- |
| same-device | opened (unchanged) | Call-via-Yivi (unchanged) |
| second-device | **disregarded** (new) | Call-via-Yivi (unchanged) |

## Tests

- New `return_url_second_device.dart`: second-device + external / in-app return
  URL → nothing opened, success confirmed in-app.
- Existing `return_url_https_external` / `_inapp` marked
  `continueOnSecondDevice: false` (they test the same-device open path).
- Verified on the iOS simulator against real irmago + staging — all 5
  return-url + calling-session tests green.

## Notes

- Builds on the second-device-flag fix (#652, merged), which makes
  `continueOnSecondDevice` reliable for camera-scanned QRs.
- The test-session helper default (`continueOnSecondDevice: true`) is kept; the
  flag is written explicitly only where a test opts out to same-device.
- Open assumption: the desktop frontend is expected to honour the return URL on
  its side. If it doesn't, second-device return URLs simply won't fire — still
  correct, since opening it on the phone was wrong either way.
