### PR TITLE
fix: show the add-data explanation cards when obtaining a credential during disclosure (#668)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Solve a proof-of-work challenge before requesting an SMS verification code in the embedded issuance flow, to make automated bulk requests expensive (no-op against issuers that do not hand out a challenge)
 
 ### Fixed
+- Obtaining a missing credential during a disclosure session now shows the same details screen as the manual add-data flow — with the credential-specific introduction and the explanation cards (which data, what you can do with it, how it works) — instead of a generic one-liner
 - Universal-link sessions are gated behind the PIN on a warm resume too, not only on cold start: when the app auto-locks after being idle and is then opened by a session link, biometric (Face ID / fingerprint) is withheld while a session is pending or in flight, so it can't unlock ahead of the incoming session
 - Scanning a desktop QR code with the phone's camera app is again treated as a second-device session instead of running the same-device return flow
 - On a second-device session, the relying party's client return URL is no longer opened in a browser on the phone (the browser session lives on the other device); the wallet confirms success locally instead. A `tel:` return URL still opens the phone dialer.

--- a/yivi_core/lib/src/providers/schemaless_credential_store_provider.dart
+++ b/yivi_core/lib/src/providers/schemaless_credential_store_provider.dart
@@ -1,3 +1,4 @@
+import "package:collection/collection.dart";
 import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../models/schemaless/credential_store.dart";
@@ -17,6 +18,15 @@ final credentialStoreProvider = StreamProvider<List<CredentialStoreItem>>((
   // `nfcAvailableProvider`.
   yield* repo.getCredentialStoreItems();
 });
+
+extension CredentialStoreItemLookup on List<CredentialStoreItem> {
+  /// The store entry for [credentialId], or null when the store has none
+  /// (e.g. non-scheme EUDI credentials). Used by the disclosure flows to
+  /// attach the store entry's FAQ to a disclosure-plan credential descriptor,
+  /// which carries no FAQ content itself.
+  CredentialStoreItem? forCredentialId(String credentialId) =>
+      firstWhereOrNull((item) => item.credential.credentialId == credentialId);
+}
 
 class CredentialStoreCategory {
   final TranslatedValue category;

--- a/yivi_core/lib/src/screens/session/widgets/disclosure_make_choice_screen.dart
+++ b/yivi_core/lib/src/screens/session/widgets/disclosure_make_choice_screen.dart
@@ -3,6 +3,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../models/schemaless/credential_store.dart";
 import "../../../models/schemaless/session_state.dart";
+import "../../../providers/schemaless_credential_store_provider.dart";
 import "../../../providers/session_state_provider.dart";
 import "../../../providers/session_user_choices_provider.dart";
 import "../../../theme/theme.dart";
@@ -91,8 +92,16 @@ class _DisclosureMakeChoiceScreenState
     if (sel.index >= obtainable.length) return;
 
     final cred = obtainable[sel.index];
+    // The disclosure plan's descriptor carries no FAQ content; that lives on
+    // the credential store entry. Attach it so the details screen shows the
+    // same explanation cards as the manual add-data flow.
+    final faq = ref
+        .read(credentialStoreProvider)
+        .value
+        ?.forCredentialId(cred.credentialId)
+        ?.faq;
     context.pushSchemalessDataDetailsScreen(
-      AddDataDetailsRouteParams(credential: cred),
+      AddDataDetailsRouteParams(credential: cred, faq: faq),
     );
   }
 

--- a/yivi_core/lib/src/screens/session/widgets/issue_during_disclosure_screen.dart
+++ b/yivi_core/lib/src/screens/session/widgets/issue_during_disclosure_screen.dart
@@ -3,6 +3,7 @@ import "package:flutter_riverpod/flutter_riverpod.dart";
 
 import "../../../models/schemaless/credential_store.dart";
 import "../../../providers/issue_during_disclosure_provider.dart";
+import "../../../providers/schemaless_credential_store_provider.dart";
 import "../../../providers/session_state_provider.dart";
 import "../../../theme/theme.dart";
 import "../../../util/navigation.dart";
@@ -43,8 +44,16 @@ class _IssueDuringDisclosureScreenState
   final _navigatorKey = GlobalKey<NavigatorState>();
 
   void _onObtainData(BuildContext context, CredentialDescriptor credential) {
+    // The disclosure plan's descriptor carries no FAQ content; that lives on
+    // the credential store entry. Attach it so the details screen shows the
+    // same explanation cards as the manual add-data flow.
+    final faq = ref
+        .read(credentialStoreProvider)
+        .value
+        ?.forCredentialId(credential.credentialId)
+        ?.faq;
     context.pushSchemalessDataDetailsScreen(
-      AddDataDetailsRouteParams(credential: credential),
+      AddDataDetailsRouteParams(credential: credential, faq: faq),
     );
   }
 

--- a/yivi_core/test/credential_store_lookup_test.dart
+++ b/yivi_core/test/credential_store_lookup_test.dart
@@ -1,0 +1,50 @@
+import "package:flutter_test/flutter_test.dart";
+import "package:yivi_core/src/models/schemaless/credential_store.dart";
+import "package:yivi_core/src/models/schemaless/schemaless_events.dart";
+import "package:yivi_core/src/models/translated_value.dart";
+import "package:yivi_core/src/providers/schemaless_credential_store_provider.dart";
+
+CredentialStoreItem _item(String credentialId) => CredentialStoreItem(
+  credential: CredentialDescriptor(
+    credentialId: credentialId,
+    name: TranslatedValue.fromString(credentialId),
+    issuer: TrustedParty(
+      id: "issuer",
+      name: TranslatedValue.fromString("Issuer"),
+      url: null,
+      parent: null,
+      verified: true,
+    ),
+    category: TranslatedValue.fromString("Personal"),
+    attributes: [],
+    issueURL: null,
+  ),
+  faq: Faq(
+    intro: TranslatedValue.fromString("intro $credentialId"),
+    purpose: TranslatedValue.fromString("purpose"),
+    content: TranslatedValue.fromString("content"),
+    howTo: TranslatedValue.fromString("howto"),
+  ),
+);
+
+void main() {
+  final store = [
+    _item("pbdf.pbdf.passport"),
+    _item("pbdf-staging.sidn-pbdf.email"),
+  ];
+
+  test("returns the store entry matching the credential id", () {
+    final item = store.forCredentialId("pbdf-staging.sidn-pbdf.email");
+
+    expect(item, isNotNull);
+    expect(item!.credential.credentialId, "pbdf-staging.sidn-pbdf.email");
+    expect(
+      item.faq.intro.translate("en"),
+      "intro pbdf-staging.sidn-pbdf.email",
+    );
+  });
+
+  test("returns null when the store has no entry for the credential id", () {
+    expect(store.forCredentialId("https://example.com/vct/eduid"), isNull);
+  });
+}


### PR DESCRIPTION
## What

When the user obtains a missing credential during a disclosure session, the
details screen now shows the same content as the manual add-data flow: the
credential-specific introduction ("Laad je e-mailadres in je Yivi-app…") and
the explanation cards — which data you retrieve, what you can do with it, and
how it works. Previously this path showed the generic fallback ("Voeg
E-mailadres toe aan mijn Yivi-app") with no cards.

Closes #668.

## How

Both flows land on the same `SchemalessAddDataDetailsScreen`; the rich content
hangs off its optional `faq` parameter. The manual add-data flow passes the
FAQ from the credential store entry, but the disclosure flows pushed only the
disclosure plan's credential descriptor, which carries no FAQ content.

- `credentialStoreProvider` gains a `forCredentialId` lookup extension on the
  store item list.
- `IssueDuringDisclosureScreen._onObtainData` and
  `DisclosureMakeChoiceScreen._onObtainData` look up the store entry for the
  descriptor's `credentialId` and pass its `faq` along. The plan descriptor
  itself remains the `credential` argument, since it carries session-specific
  data such as verifier-requested attribute values (#507 / #583).
- Credentials without a store entry (e.g. non-scheme EUDI credentials) keep
  the current fallback behavior.

## Tests

- `yivi_core/test/credential_store_lookup_test.dart` — the lookup returns the
  matching store entry and null for unknown credential ids.

`flutter test` (170 tests) passes, `flutter analyze` is clean on the changed
files, and `dart format` is clean.

## Test plan

- [ ] Start a disclosure session requesting an email credential the wallet
      does not hold (e.g. the "Email" preset on
      https://verifier.openid4vc.staging.yivi.app/), tap the obtain button,
      and check that the details screen shows the intro text and the
      explanation cards instead of the generic one-liner.
