### PR TITLE
chore(deps): bump vcmrtd to v3.9.1 (skip AA when chip has no DG15)

### DIFF
--- a/yivi_app/pubspec.lock
+++ b/yivi_app/pubspec.lock
@@ -193,14 +193,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
-  diffie_hellman:
-    dependency: transitive
-    description:
-      name: diffie_hellman
-      sha256: cf88adea8d7c56ed145e95db87e61297c52d236c2faace48fbcb425a73ddeba6
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2"
   dlibphonenumber:
     dependency: transitive
     description:
@@ -1360,9 +1352,9 @@ packages:
   vcmrtd:
     dependency: "direct dev"
     description:
-      path: "."
-      ref: "v3.8.0"
-      resolved-ref: ab3cc91b643b4d90f03f2cc493dbcefeac1d7342
+      path: vcmrtd
+      ref: "v3.9.1"
+      resolved-ref: e2b80c941ce2decd626674f5e0899f3bd854aba8
       url: "https://github.com/privacybydesign/vcmrtd.git"
     source: git
     version: "2.0.0"

--- a/yivi_app/pubspec.yaml
+++ b/yivi_app/pubspec.yaml
@@ -45,7 +45,9 @@ dev_dependencies:
   vcmrtd:
     git:
       url: https://github.com/privacybydesign/vcmrtd.git
-      ref: v3.8.0
+      # Must match the ref in yivi_core/pubspec.yaml.
+      ref: v3.9.1
+      path: vcmrtd
   package_info_plus: ^10.1.0
   collection: ^1.18.0
   rxdart: ^0.28.0

--- a/yivi_core/pubspec.lock
+++ b/yivi_core/pubspec.lock
@@ -281,14 +281,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
-  diffie_hellman:
-    dependency: transitive
-    description:
-      name: diffie_hellman
-      sha256: cf88adea8d7c56ed145e95db87e61297c52d236c2faace48fbcb425a73ddeba6
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2"
   dlibphonenumber:
     dependency: transitive
     description:
@@ -1472,9 +1464,9 @@ packages:
   vcmrtd:
     dependency: "direct main"
     description:
-      path: "."
-      ref: "v3.8.0"
-      resolved-ref: ab3cc91b643b4d90f03f2cc493dbcefeac1d7342
+      path: vcmrtd
+      ref: "v3.9.1"
+      resolved-ref: e2b80c941ce2decd626674f5e0899f3bd854aba8
       url: "https://github.com/privacybydesign/vcmrtd.git"
     source: git
     version: "2.0.0"

--- a/yivi_core/pubspec.yaml
+++ b/yivi_core/pubspec.yaml
@@ -58,7 +58,11 @@ dependencies:
   vcmrtd:
     git:
       url: https://github.com/privacybydesign/vcmrtd.git
-      ref: v3.8.0
+      # v3.9.1 skips Active Authentication when the chip has no DG15 (fixes
+      # 6A88 read failures on documents that use Chip Authentication, e.g. UK).
+      # From v3.9.x the package lives one directory deeper, hence `path`.
+      ref: v3.9.1
+      path: vcmrtd
   mask_text_input_formatter: ^2.9.0
   jailbreak_root_detection: ^1.2.0+1
   # Temporary forks because their original repos are not compatible with new android api's.

--- a/yivi_fdroid/pubspec.lock
+++ b/yivi_fdroid/pubspec.lock
@@ -193,14 +193,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.3.0"
-  diffie_hellman:
-    dependency: transitive
-    description:
-      name: diffie_hellman
-      sha256: cf88adea8d7c56ed145e95db87e61297c52d236c2faace48fbcb425a73ddeba6
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.1.2"
   dlibphonenumber:
     dependency: transitive
     description:
@@ -1385,9 +1377,9 @@ packages:
   vcmrtd:
     dependency: transitive
     description:
-      path: "."
-      ref: "v3.8.0"
-      resolved-ref: ab3cc91b643b4d90f03f2cc493dbcefeac1d7342
+      path: vcmrtd
+      ref: "v3.9.1"
+      resolved-ref: e2b80c941ce2decd626674f5e0899f3bd854aba8
       url: "https://github.com/privacybydesign/vcmrtd.git"
     source: git
     version: "2.0.0"


### PR DESCRIPTION
Bumps the `vcmrtd` git dependency from **v3.8.0** to **v3.9.1** in `yivi_core` and `yivi_app` (lockfiles updated for `yivi_core`, `yivi_app`, `yivi_fdroid`).

## Why

A UK prospect could not scan their UK passport on Android: the read aborted on the Active Authentication step with `Referenced data not found` (SW `6A88`) after 5 retries, even though all mandatory data had already been read.

vcmrtd attempted Active Authentication unconditionally, without checking whether the chip carries an AA public key (DG15). Documents that rely on Chip Authentication (EAC) instead of AA have no DG15, so `INTERNAL AUTHENTICATE` returns `6A88`; only `6D00` was tolerated, so the whole read failed.

## What v3.9.1 changes

- Gates Active Authentication on DG15 presence — no DG15 → AA is skipped cleanly (no `INTERNAL AUTHENTICATE` sent).
- Treats the "not supported" status words `6A88`/`6A81`/`6D00` as a graceful skip rather than a fatal error.

The `go-passport-issuer` backend already accepts a null AA signature for documents without DG15 (passive authentication of the SOD stays mandatory), so no backend change is required.

## Note

From v3.9.x the vcmrtd package lives one directory deeper in its repo, so the git dependency now needs `path: vcmrtd` (added alongside the ref bump). Verified `flutter pub get` resolves in all three packages and `flutter analyze` on `yivi_core/lib` is clean.
