### PR TITLE
Upgrade vcmrtd to v4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The same for the optional error reporting checkbox, and the sentence beside it is read as one phrase rather than broken into "Optional:", "Share error messages and app status" and "with Yivi"
 - On the PIN screen, a screen reader announces the "Enter your PIN" heading and how many digits you have entered as separate items; the whole screen used to be a single item that fused the two and offered a pointless tap
 - The screen that sends you back to your browser on iOS is read out as soon as it appears, so you are told what to do rather than being left on a silent screen, and the decorative arrow is no longer announced as an unnamed image
+- Reading a driving licence now performs Active Authentication when the chip carries the licence's authentication key in DG13; it was previously only performed for documents that store that key in DG15, so it was never attempted for a licence
 
 ### Internal
 - The Go client schedules the credential status refresh again and wakes the app itself through the new `ClientHandler.CredentialsChanged`
@@ -32,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated Git submodules
 - Fix swallowed errors on cancelling embedded issuance flows
 - The F-Droid build steps now live in `yivi_fdroid/fdroid_build.sh` with a test that runs them against stub tooling, instead of being inlined in the fdroiddata recipe once per release
+- Upgrade vcmrtd to v4.0.0: the BAC, PACE and secure-messaging MAC comparisons are constant-time, and the challenge/response and APDU hex dumps are behind the sensitive-data log gate rather than plain verbose logging
+- The passport issuer's session URL is checked before the IRMA JWT carrying the chip scan is posted to it: it must be https and on an explicit allowlist of IRMA server hosts
 
 ## [8.1.2] - 2026-07-22
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix swallowed errors on cancelling embedded issuance flows
 - The F-Droid build steps now live in `yivi_fdroid/fdroid_build.sh` with a test that runs them against stub tooling, instead of being inlined in the fdroiddata recipe once per release
 - Upgrade vcmrtd to v4.0.0: the BAC, PACE and secure-messaging MAC comparisons are constant-time, and the challenge/response and APDU hex dumps are behind the sensitive-data log gate rather than plain verbose logging
-- The passport issuer's session URL is checked before the IRMA JWT carrying the chip scan is posted to it: it must be https and on an explicit allowlist of IRMA server hosts
+- The passport issuer's session URL is checked before the signed IRMA issuance request, which carries the attributes read off the chip, is posted to it: it must be https and on an explicit allowlist of IRMA server hosts
 
 ## [8.1.2] - 2026-07-22
 ### Added

--- a/yivi_app/pubspec.lock
+++ b/yivi_app/pubspec.lock
@@ -1353,8 +1353,8 @@ packages:
     dependency: "direct dev"
     description:
       path: vcmrtd
-      ref: "v3.9.1"
-      resolved-ref: e2b80c941ce2decd626674f5e0899f3bd854aba8
+      ref: "v4.0.0"
+      resolved-ref: "49bb35dde82ec9d968e52dabb6109285805969c8"
       url: "https://github.com/privacybydesign/vcmrtd.git"
     source: git
     version: "2.0.0"

--- a/yivi_app/pubspec.yaml
+++ b/yivi_app/pubspec.yaml
@@ -45,8 +45,10 @@ dev_dependencies:
   vcmrtd:
     git:
       url: https://github.com/privacybydesign/vcmrtd.git
-      # Must match the ref in yivi_core/pubspec.yaml.
-      ref: v3.9.1
+      # Must match the ref in yivi_core/pubspec.yaml. As of v4.0.0 the repo is a
+      # multi-package monorepo; we consume only the `vcmrtd` package (hence
+      # `path`), not the separate `mrz_capture` scanner module.
+      ref: v4.0.0
       path: vcmrtd
   package_info_plus: ^10.1.0
   collection: ^1.18.0

--- a/yivi_core/lib/src/providers/passport_issuer_provider.dart
+++ b/yivi_core/lib/src/providers/passport_issuer_provider.dart
@@ -10,13 +10,16 @@ final passportIssuerUrlProvider = NotifierProvider(
 /// Hosts the passport issuer is allowed to hand the app an `irma_server_url`
 /// for.
 ///
-/// [DefaultPassportIssuer] posts the IRMA JWT, which carries the raw biometric
-/// chip scan, to the `irma_server_url` the passport issuer returns, and refuses
-/// any host outside this list. The IRMA server runs on a different host than
-/// the passport issuer, so listing it explicitly is required: the constructor
-/// default is the host of [passportIssuerUrlProvider], which never matches.
-/// Both environments are listed because [passportIssuerUrlProvider] is set at
-/// runtime from the issue URL in the scheme.
+/// [DefaultPassportIssuer] posts the signed IRMA issuance request to the
+/// `irma_server_url` the passport issuer returns, and refuses any host outside
+/// this list. That JWT is not the raw chip scan: the data groups and EF.SOD go
+/// to [passportIssuerUrlProvider] itself, which this list does not cover. It
+/// does carry the attributes derived from the chip, including the facial
+/// image. The IRMA server runs on a different host than the passport issuer,
+/// so listing it explicitly is required: the constructor default is the host
+/// of [passportIssuerUrlProvider], which never matches. Both environments are
+/// listed because [passportIssuerUrlProvider] is set at runtime from the issue
+/// URL in the scheme.
 final allowedIrmaHostsProvider = Provider<Set<String>>(
   (ref) => const {"is.yivi.app", "is.staging.yivi.app"},
 );

--- a/yivi_core/lib/src/providers/passport_issuer_provider.dart
+++ b/yivi_core/lib/src/providers/passport_issuer_provider.dart
@@ -7,9 +7,25 @@ final passportIssuerUrlProvider = NotifierProvider(
   () => helpers.ValueNotifier("https://passport-issuer.staging.yivi.app"),
 );
 
+/// Hosts the passport issuer is allowed to hand the app an `irma_server_url`
+/// for.
+///
+/// [DefaultPassportIssuer] posts the IRMA JWT, which carries the raw biometric
+/// chip scan, to the `irma_server_url` the passport issuer returns, and refuses
+/// any host outside this list. The IRMA server runs on a different host than
+/// the passport issuer, so listing it explicitly is required: the constructor
+/// default is the host of [passportIssuerUrlProvider], which never matches.
+/// Both environments are listed because [passportIssuerUrlProvider] is set at
+/// runtime from the issue URL in the scheme.
+final allowedIrmaHostsProvider = Provider<Set<String>>(
+  (ref) => const {"is.yivi.app", "is.staging.yivi.app"},
+);
+
 final passportIssuerProvider = Provider<PassportIssuer>(
-  (ref) =>
-      DefaultPassportIssuer(hostName: ref.watch(passportIssuerUrlProvider)),
+  (ref) => DefaultPassportIssuer(
+    hostName: ref.watch(passportIssuerUrlProvider),
+    allowedIrmaHosts: ref.watch(allowedIrmaHostsProvider),
+  ),
 );
 
 class ErrorThrowingPassportIssuer implements PassportIssuer {

--- a/yivi_core/pubspec.lock
+++ b/yivi_core/pubspec.lock
@@ -1465,8 +1465,8 @@ packages:
     dependency: "direct main"
     description:
       path: vcmrtd
-      ref: "v3.9.1"
-      resolved-ref: e2b80c941ce2decd626674f5e0899f3bd854aba8
+      ref: "v4.0.0"
+      resolved-ref: "49bb35dde82ec9d968e52dabb6109285805969c8"
       url: "https://github.com/privacybydesign/vcmrtd.git"
     source: git
     version: "2.0.0"

--- a/yivi_core/pubspec.yaml
+++ b/yivi_core/pubspec.yaml
@@ -58,8 +58,11 @@ dependencies:
   vcmrtd:
     git:
       url: https://github.com/privacybydesign/vcmrtd.git
-      # v3.9.1 skips Active Authentication when the chip has no DG15 (fixes
-      # 6A88 read failures on documents that use Chip Authentication, e.g. UK).
+      # Active Authentication is attempted only when the chip carries an AA
+      # public key (fixes 6A88 read failures on documents that use Chip
+      # Authentication, e.g. UK). As of v4.0.0 that means DG15 for passports
+      # and ID cards, and DG13 for driving licences, which before v4.0.0
+      # never attempted AA at all.
       # As of v4.0.0 the repo is a multi-package monorepo: the NFC reading
       # library is the `vcmrtd` package (hence `path`), while MRZ scanning lives
       # in a separate `mrz_capture` package and face verification in

--- a/yivi_core/pubspec.yaml
+++ b/yivi_core/pubspec.yaml
@@ -60,8 +60,13 @@ dependencies:
       url: https://github.com/privacybydesign/vcmrtd.git
       # v3.9.1 skips Active Authentication when the chip has no DG15 (fixes
       # 6A88 read failures on documents that use Chip Authentication, e.g. UK).
-      # From v3.9.x the package lives one directory deeper, hence `path`.
-      ref: v3.9.1
+      # As of v4.0.0 the repo is a multi-package monorepo: the NFC reading
+      # library is the `vcmrtd` package (hence `path`), while MRZ scanning lives
+      # in a separate `mrz_capture` package and face verification in
+      # `face_verification`. We only consume `vcmrtd`; the app keeps its own
+      # scanner so the F-Droid build stays free of Google ML Kit, which
+      # `mrz_capture` would pull in.
+      ref: v4.0.0
       path: vcmrtd
   mask_text_input_formatter: ^2.9.0
   jailbreak_root_detection: ^1.2.0+1

--- a/yivi_core/test/passport_issuer_allowed_hosts_test.dart
+++ b/yivi_core/test/passport_issuer_allowed_hosts_test.dart
@@ -1,0 +1,57 @@
+import "package:flutter_riverpod/flutter_riverpod.dart";
+import "package:flutter_test/flutter_test.dart";
+import "package:vcmrtd/vcmrtd.dart";
+import "package:yivi_core/src/providers/passport_issuer_provider.dart";
+
+/// The IRMA server the passport issuer hands back in `irma_server_url`. It is a
+/// different service than the passport issuer itself, see the `irma_server_url`
+/// key in go-passport-issuer's config.
+const _stagingIrmaServer = "https://is.staging.yivi.app";
+const _productionIrmaServer = "https://is.yivi.app";
+
+DefaultPassportIssuer _issuerFor(String passportIssuerUrl) {
+  final container = ProviderContainer();
+  addTearDown(container.dispose);
+  container.read(passportIssuerUrlProvider.notifier).set(passportIssuerUrl);
+  return container.read(passportIssuerProvider) as DefaultPassportIssuer;
+}
+
+void main() {
+  group("passportIssuerProvider allowed IRMA hosts", () {
+    test("accepts the IRMA server the staging passport issuer returns", () {
+      final issuer = _issuerFor("https://passport-issuer.staging.yivi.app");
+
+      expect(
+        issuer.validateSessionUrl(_stagingIrmaServer).host,
+        "is.staging.yivi.app",
+      );
+    });
+
+    test("accepts the IRMA server the production passport issuer returns", () {
+      final issuer = _issuerFor("https://passport-issuer.yivi.app");
+
+      expect(
+        issuer.validateSessionUrl(_productionIrmaServer).host,
+        "is.yivi.app",
+      );
+    });
+
+    test("rejects a session URL on any other host", () {
+      final issuer = _issuerFor("https://passport-issuer.staging.yivi.app");
+
+      expect(
+        () => issuer.validateSessionUrl("https://attacker.example"),
+        throwsException,
+      );
+    });
+
+    test("rejects a session URL that is not https", () {
+      final issuer = _issuerFor("https://passport-issuer.staging.yivi.app");
+
+      expect(
+        () => issuer.validateSessionUrl("http://is.staging.yivi.app"),
+        throwsException,
+      );
+    });
+  });
+}

--- a/yivi_core/test/passport_issuer_allowed_hosts_test.dart
+++ b/yivi_core/test/passport_issuer_allowed_hosts_test.dart
@@ -50,7 +50,13 @@ void main() {
 
       expect(
         () => issuer.validateSessionUrl("http://is.staging.yivi.app"),
-        throwsException,
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            "message",
+            contains("non-https"),
+          ),
+        ),
       );
     });
   });

--- a/yivi_core/test/passport_issuer_allowed_hosts_test.dart
+++ b/yivi_core/test/passport_issuer_allowed_hosts_test.dart
@@ -41,7 +41,13 @@ void main() {
 
       expect(
         () => issuer.validateSessionUrl("https://attacker.example"),
-        throwsException,
+        throwsA(
+          isA<Exception>().having(
+            (e) => e.toString(),
+            "message",
+            contains("not in the allowed host list"),
+          ),
+        ),
       );
     });
 

--- a/yivi_fdroid/pubspec.lock
+++ b/yivi_fdroid/pubspec.lock
@@ -1378,8 +1378,8 @@ packages:
     dependency: transitive
     description:
       path: vcmrtd
-      ref: "v3.9.1"
-      resolved-ref: e2b80c941ce2decd626674f5e0899f3bd854aba8
+      ref: "v4.0.0"
+      resolved-ref: "49bb35dde82ec9d968e52dabb6109285805969c8"
       url: "https://github.com/privacybydesign/vcmrtd.git"
     source: git
     version: "2.0.0"


### PR DESCRIPTION
## What

Bumps `vcmrtd` from `v3.9.1` to `v4.0.0` in `yivi_core` and `yivi_app` (and refreshes all three lockfiles, including `yivi_fdroid`, which pulls it in transitively), and pins the IRMA server hosts the passport issuer is allowed to point the app at.

## What actually changes

The `vcmrtd` package's three barrel files (`vcmrtd.dart`, `internal.dart`, `extensions.dart`) are byte-identical between v3.9.1 and v4.0.0, so no existing call site moves and the package still lives at `path: vcmrtd`. The API surface reachable through them did grow, though — `DefaultPassportIssuer` gained the `allowedIrmaHosts` constructor parameter and the `validateSessionUrl` method that this PR depends on. And eight files under `lib/src/` changed, three of them in ways that matter here.

**Session URL validation**, which is why this PR is more than a ref bump. `DefaultPassportIssuer` now validates the server-supplied `irma_server_url` before posting the signed IRMA issuance request to it: it must be absolute, https, and on `allowedIrmaHosts`. That JWT is not the raw chip scan — the data groups and EF.SOD go to `hostName` (the passport issuer) on a hop this allowlist does not cover — but it does carry the attributes the issuer derived from the chip, including the facial image. If that list is not passed it defaults to the host of `hostName`, which is the passport issuer. The IRMA server is a different service: `go-passport-issuer` returns `https://is.staging.yivi.app` while `hostName` is `https://passport-issuer.staging.yivi.app`, so the default never matches and every document issuance would throw, right after the user has completed the MRZ scan and the entire NFC read. This PR sets the list explicitly, with both the staging and the production IRMA server, because `passportIssuerUrlProvider` is set at runtime from the issue URL in the scheme.

Note that the https-only branch also refuses a local dev issuer that returns an `http://` session URL, and no `allowedIrmaHosts` value changes that.

**Constant-time comparisons**: a new `constantTimeEqual` replaces `ListEquality().equals` for the BAC RND.IFD check, the BAC MAC check, the secure-messaging response MAC, and both PACE auth-token comparisons.

**Less in the logs**: the RND.IC, RND.IFD, Eifd, Mifd, Eicc, Micc, decrypted R and APDU CC hex dumps moved from `verbose` to the sensitive-data-gated `sdVerbose`, and one `BACError` no longer puts the ephemeral nonce hex in its message.

## One thing to test on device

The Active Authentication gate moved from a hardcoded DG15 check to an overridable `documentSupportsActiveAuthentication()`, and `DrivingLicenceParser` overrides it to check DG13. On v3.9.1, AA was never attempted for a driving licence; on v4.0.0 it is attempted whenever DG13 is present, and `drivingLicenceReaderProvider` does read DG13. `go-passport-issuer` treats a present DG13 as making AA mandatory, so this reads as a fix for driving licence issuance rather than a risk to it. Still, please give it one pass with a real Dutch licence before merge.

## Why "mrz scanner is its own module now"

v4.0.0 turns the repo into a multi-package monorepo:

- `vcmrtd`: the NFC / ICAO-9303 reading library (what we consume)
- `mrz_capture`: the MRZ scanner, now split out into its own module
- `face_verification`: biometrics

## F-Droid stays Google-free

We deliberately do not adopt the new `mrz_capture` module. It hard-depends on `google_mlkit_text_recognition` and bundles both OCR engines, which would pull proprietary Google code into the libre F-Droid build. The app keeps its existing scanner and `OcrProcessor` injection split, so `yivi_fdroid` remains Tesseract-only (verified: 0 `mrz_capture` / 0 `google_mlkit` entries in its lockfile).

## Testing

`yivi_core/test/passport_issuer_allowed_hosts_test.dart` covers the allowlist. It drives `validateSessionUrl` through the real provider, so on the implicit default it fails with `Session URL host "is.staging.yivi.app" is not in the allowed host list`, and passes with the explicit list. The integration tests do not reach this path: they inject `FakePassportIssuer`, which implements the `PassportIssuer` interface directly.

`flutter analyze` and `dart format --set-exit-if-changed` pass on `yivi_core`, `yivi_app` and `yivi_fdroid`. The `yivi_core` suite is 214 tests green.

